### PR TITLE
Fix invalid opcode and unmapped memory handling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,10 +103,10 @@ cdef class Component:
     cdef unsigned int _size
     cdef str _name
 
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         return 0
 
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         return 0
 
     cdef void bind(self, object system):
@@ -141,10 +141,10 @@ cdef class Memory(Component):
     cdef unsigned char[::1] _data
     cdef bint _read_only
 
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         return self._data[address]
 
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         if not self._read_only:
             self._data[address] = data
         return data
@@ -179,9 +179,24 @@ checking is explicitly disabled via `@boundscheck(False)` because the
 address is already masked to 16 bits).
 
 Unmapped addresses point at an `EmptyAddress` sentinel instance. The
-sentinel can optionally raise on access (useful during development for
-spotting bugs) or return a sensible default (useful once the machine is
-stable).
+sentinel's behavior is user-configurable at runtime:
+
+- **Open bus** (default): reads return the last value on the data bus,
+  writes are silently dropped. This matches real 6502 hardware behavior.
+- **Crash**: reads and writes raise `UnallocatedAddressError`, which
+  propagates through the `except *` call chain to the UI. The UI pauses
+  the simulator and only allows a reset to resume.
+
+Invalid opcodes follow a similar pattern in `MOS6502.load_op_code()`:
+
+- **Crash** (default): raises `InvalidOPCode` with the opcode byte and
+  address. The UI catches it and pauses.
+- **NOP**: the invalid opcode is treated as a 2-cycle implied NOP and
+  execution continues.
+
+Both settings are toggled through `System.set_unmapped_memory_mode()`
+and `System.set_invalid_opcode_mode()`, exposed in the UI's Settings
+menu.
 
 `BusController.add_component(component, address_start)`:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,12 +60,9 @@ wrong here, every later release pays for it.
 **Open issues in GitHub milestone "v0.1 Release - First 6502 release":**
 
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
-- [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM and (now retired) ASM
+- [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
 - [#8](https://github.com/ricky-groenewald/py6502/issues/8) — Basic User Interface
-- [#25](https://github.com/ricky-groenewald/py6502/issues/25) — [BUG] Invalid opcodes / unmapped memory accesses
-- [#29](https://github.com/ricky-groenewald/py6502/issues/29) — Abstractize display + input devices
-- [#31](https://github.com/ricky-groenewald/py6502/issues/31) — Apple I authenticity
-- [#34](https://github.com/ricky-groenewald/py6502/issues/34) — Implement `py6502.sim.system` against IaC spec
+- [#25](https://github.com/ricky-groenewald/py6502/issues/25) — [BUG] On invalid opcodes / invalid memory addresses
 
 **Explicit non-goals for v0.1.**
 
@@ -123,16 +120,16 @@ divider-aware before it's useful.
 **Open issues in GitHub milestone "v0.2 Release - Famicom / NES release":**
 
 - [#2](https://github.com/ricky-groenewald/py6502/issues/2) — 6502: Create tests
-- [#4](https://github.com/ricky-groenewald/py6502/issues/4) — GitHub Actions: automated testing
-- [#6](https://github.com/ricky-groenewald/py6502/issues/6) — 6502 illegal opcodes
-- [#12](https://github.com/ricky-groenewald/py6502/issues/12) — NES emulation
-- [#13](https://github.com/ricky-groenewald/py6502/issues/13) — Cartridge loading / mappers
-- [#14](https://github.com/ricky-groenewald/py6502/issues/14) — Character / tile map display
-- [#15](https://github.com/ricky-groenewald/py6502/issues/15) — Background display
-- [#16](https://github.com/ricky-groenewald/py6502/issues/16) — Sprites display
-- [#17](https://github.com/ricky-groenewald/py6502/issues/17) — Controller input
+- [#4](https://github.com/ricky-groenewald/py6502/issues/4) — Github actions: Automated testing upon pushing / PR / etc.
+- [#6](https://github.com/ricky-groenewald/py6502/issues/6) — Add 6502 illegal opcodes support
+- [#12](https://github.com/ricky-groenewald/py6502/issues/12) — NES Emulation
+- [#13](https://github.com/ricky-groenewald/py6502/issues/13) — Cartridge Loading / Mappers
+- [#14](https://github.com/ricky-groenewald/py6502/issues/14) — Character / Tile map display
+- [#15](https://github.com/ricky-groenewald/py6502/issues/15) — Background Display
+- [#16](https://github.com/ricky-groenewald/py6502/issues/16) — Sprites Display
+- [#17](https://github.com/ricky-groenewald/py6502/issues/17) — Controller Input
 - [#18](https://github.com/ricky-groenewald/py6502/issues/18) — Audio
-- [#27](https://github.com/ricky-groenewald/py6502/issues/27) — Variable timing / clock model
+- [#27](https://github.com/ricky-groenewald/py6502/issues/27) — Variable Timing/Clock Model
 - [#32](https://github.com/ricky-groenewald/py6502/issues/32) — Multiprocessing sim/frontend split
 - [#33](https://github.com/ricky-groenewald/py6502/issues/33) — Frontend library re-evaluation (DearPyGui friction)
 
@@ -165,11 +162,11 @@ fixture scaffolding itself ships in v0.1; v0.2 expands it.
 
 **Open issues in GitHub milestone "v0.3 Release - Development Tools":**
 
-- [#5](https://github.com/ricky-groenewald/py6502/issues/5) — 65C02 opcode support
+- [#5](https://github.com/ricky-groenewald/py6502/issues/5) — Add 65c02 opcode support
 - [#19](https://github.com/ricky-groenewald/py6502/issues/19) — Complete assembler solution
-- [#21](https://github.com/ricky-groenewald/py6502/issues/21) — Customize + package DearPyGui
-- [#24](https://github.com/ricky-groenewald/py6502/issues/24) — Save code snippets
-- [#26](https://github.com/ricky-groenewald/py6502/issues/26) — Character map / sprite editors
+- [#21](https://github.com/ricky-groenewald/py6502/issues/21) — Customize and package dearpygui/imgui
+- [#24](https://github.com/ricky-groenewald/py6502/issues/24) — Enable saving of code snippets
+- [#26](https://github.com/ricky-groenewald/py6502/issues/26) — Character Map / Sprite Editors
 
 ---
 

--- a/src/py6502/sim/bus/buscontroller.pxd
+++ b/src/py6502/sim/bus/buscontroller.pxd
@@ -33,11 +33,14 @@ cdef class BusController(Component):
     cpdef void testme(self)
     cpdef bint check_success(self)
 
-    cpdef void clock(self)
-    cpdef void run_cycles(self, unsigned long cycles)
-    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz)
+    cpdef void clock(self) except *
+    cpdef void run_cycles(self, unsigned long cycles) except *
+    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *
 
     cpdef void send_reset(self)
 
     cpdef Registers get_registers(self)
     cpdef void set_registers(self, Registers registers)
+
+    cpdef bint is_mapped(self, unsigned short address)
+    cpdef void set_unmapped_memory_mode(self, bint crash)

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -7,6 +7,7 @@ from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
 from cython cimport boundscheck, wraparound
 from py6502.sim.bus.component cimport Component
 from py6502.sim.bus.emptyaddress cimport EmptyAddress
+from py6502.sim.bus.emptyaddress import UnallocatedAddressError
 from py6502.sim.cpu.mos6502 cimport MOS6502, Registers
 
 class ComponentSizeError(Exception):
@@ -36,6 +37,7 @@ cdef class BusController(Component):
             'EmptyAddress',
             raise_on_unmapped_access
         )
+        self._empty_address.set_bus_data_ptr(&self._current_bus_data)
 
         for i in range(0x10000):
             self._component_address_map[i].component = <PyObject*>self._empty_address
@@ -97,10 +99,10 @@ cdef class BusController(Component):
     cpdef bint check_success(self):
         return self.read(0x0200) == 0xF0
 
-    cpdef void clock(self):
+    cpdef void clock(self) except *:
         self._processor.clock()
 
-    cpdef void run_cycles(self, unsigned long cycles):
+    cpdef void run_cycles(self, unsigned long cycles) except *:
         cdef Py_ssize_t hook_idx
         cdef Py_ssize_t hook_count
         for _ in range(cycles):
@@ -109,7 +111,7 @@ cdef class BusController(Component):
         for hook_idx in range(hook_count):
             (<Component>self._tick_hooks[hook_idx]).on_cycles_elapsed(cycles)
 
-    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz):
+    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *:
         cdef unsigned long cycles = (microseconds * cpu_hz) // 1000000
         if cycles:
             self.run_cycles(cycles)
@@ -123,6 +125,13 @@ cdef class BusController(Component):
     cpdef void set_registers(self, Registers registers):
         self._processor.set_registers(registers)
 
+    cpdef bint is_mapped(self, unsigned short address):
+        return (<Component>self._component_address_map[address].component
+                is not self._empty_address)
+
+    cpdef void set_unmapped_memory_mode(self, bint crash):
+        self._empty_address._raise_on_unmapped = crash
+
     def get_bus_values(self):
         return (
             self._current_bus_address,
@@ -134,11 +143,14 @@ cdef class BusController(Component):
     # Bounds checking disabled since short address is always within bus controller's address range
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         cdef MappedAddress mapped_address = self._component_address_map[address]
 
         self._current_bus_address = address
-        self._current_bus_data = (<Component>mapped_address.component).read(mapped_address.internal_address)
+        try:
+            self._current_bus_data = (<Component>mapped_address.component).read(mapped_address.internal_address)
+        except UnallocatedAddressError:
+            raise
         self._current_bus_read_write_bar = 1
 
         return self._current_bus_data
@@ -147,11 +159,14 @@ cdef class BusController(Component):
     # Bounds checking disabled since short address is always within bus controller's address range
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         cdef MappedAddress mapped_address = self._component_address_map[address]
 
         self._current_bus_address = address
-        self._current_bus_data = (<Component>mapped_address.component).write(mapped_address.internal_address, data)
+        try:
+            self._current_bus_data = (<Component>mapped_address.component).write(mapped_address.internal_address, data)
+        except UnallocatedAddressError:
+            raise
         self._current_bus_read_write_bar = 0
 
         return self._current_bus_data

--- a/src/py6502/sim/bus/component.pxd
+++ b/src/py6502/sim/bus/component.pxd
@@ -7,7 +7,7 @@ cdef class Component:
     cdef readonly str _name
     cdef inline str get_name(self)
     cdef inline unsigned int get_size(self)
-    cdef unsigned char read(self, unsigned short address)
-    cdef unsigned char write(self, unsigned short address, unsigned char data)
+    cdef unsigned char read(self, unsigned short address) except *
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)

--- a/src/py6502/sim/bus/component.pyx
+++ b/src/py6502/sim/bus/component.pyx
@@ -38,7 +38,7 @@ cdef class Component:
         return self._size
 
     # Abstract class
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         """
         SHOULD NOT BE ACCESSED PUBLICLY
 
@@ -53,7 +53,7 @@ cdef class Component:
         raise NotImplementedError("Subclass must implement this method")
 
     # Abstract class
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         """
         SHOULD NOT BE ACCESSED PUBLICLY
 

--- a/src/py6502/sim/bus/emptyaddress.pxd
+++ b/src/py6502/sim/bus/emptyaddress.pxd
@@ -2,6 +2,8 @@ from py6502.sim.bus.component cimport Component
 
 cdef class EmptyAddress(Component):
     cdef bint _raise_on_unmapped
+    cdef unsigned char* _bus_data_ptr
 
-    cdef unsigned char read(self, unsigned short address)
-    cdef unsigned char write(self, unsigned short address, unsigned char data)
+    cdef unsigned char read(self, unsigned short address) except *
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
+    cdef void set_bus_data_ptr(self, unsigned char* ptr)

--- a/src/py6502/sim/bus/emptyaddress.pyx
+++ b/src/py6502/sim/bus/emptyaddress.pyx
@@ -19,23 +19,25 @@ cdef class EmptyAddress(Component):
         # The size is arbitrary because the internal address passed in is ignored.
         super().__init__(0, name)
         self._raise_on_unmapped = raise_on_unmapped
+        self._bus_data_ptr = NULL
+
+    cdef void set_bus_data_ptr(self, unsigned char* ptr):
+        self._bus_data_ptr = ptr
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'
             )
-        else:
-            return 0
+        return self._bus_data_ptr[0]
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'
             )
-        else:
-            return 0 
+        return data

--- a/src/py6502/sim/bus/memory.pyx
+++ b/src/py6502/sim/bus/memory.pyx
@@ -39,14 +39,14 @@ cdef class Memory(Component):
     # Bounds checking disabled since read should only be accessed through the bus controller
     @boundscheck(False)
     @wraparound(False)
-    cdef inline unsigned char read(self, unsigned short address):
+    cdef inline unsigned char read(self, unsigned short address) except *:
         return self._data[address]
 
     # Wraparound disabled since address is strictly positive
     # Bounds checking disabled since write should only be accessed through the bus controller
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         if not self._read_only:
             self._data[address] = data
 

--- a/src/py6502/sim/cpu/mos6502.pxd
+++ b/src/py6502/sim/cpu/mos6502.pxd
@@ -3,7 +3,7 @@ CYTHON MOS6502 PROCESSOR CLASS DECLARATIONS
 """
 from py6502.sim.bus.component cimport Component
 
-ctypedef void (*instruction_func)(MOS6502)
+ctypedef void (*instruction_func)(MOS6502) except *
 
 cdef struct Registers:
     unsigned char OPCODE # Not a real register, but used for debugging
@@ -26,6 +26,7 @@ cdef class MOS6502:
     cdef Component _memory_bus
 
     # Internal variables
+    cdef unsigned char _invalid_opcode_mode  # 0 = NOP, 1 = crash
     cdef unsigned char _cycle_number
     cdef unsigned char _temp_data
     cdef unsigned short _temp_address
@@ -48,11 +49,12 @@ cdef class MOS6502:
     cdef void set_registers(self, Registers registers)
 
     # Control Functions
-    cdef void clock(self)
+    cdef void clock(self) except *
     cdef void send_reset(self)
     cdef void send_irq(self)
     cdef void send_nmi(self)
-    cdef void load_op_code(self)
+    cdef void load_op_code(self) except *
+    cdef void set_invalid_opcode_mode(self, unsigned char mode)
     cdef void clear_bcd_opcodes(self)
     cdef void set_bcd_opcodes(self)
 

--- a/src/py6502/sim/cpu/mos6502.pyx
+++ b/src/py6502/sim/cpu/mos6502.pyx
@@ -34,6 +34,7 @@ cdef class MOS6502:
     def __init__(self) -> None:
         # Initialize internal and external variables
         self._memory_bus = None
+        self._invalid_opcode_mode = 1  # 0 = NOP, 1 = crash (default)
         self._cycle_number = 0x00
         self._temp_data = 0x00
         self._temp_address = 0x0000
@@ -271,10 +272,13 @@ cdef class MOS6502:
     def set_memory_bus(self, Component memory_bus):
         self._memory_bus = memory_bus
 
+    cdef void set_invalid_opcode_mode(self, unsigned char mode):
+        self._invalid_opcode_mode = mode
+
     ###
     #   CONTROL FUNCTIONS
     ###
-    cdef void clock(self):
+    cdef void clock(self) except *:
         if self._current_instruction:
             self._current_instruction(self)
         else:
@@ -330,7 +334,15 @@ cdef class MOS6502:
             self._current_instruction = self._instructions[self._registers.OPCODE][0]
             self._next_instruction = self._instructions[self._registers.OPCODE][1]
             if self._current_instruction is NULL:
-                raise InvalidOPCode(f'Invalid OPCODE: 0x{self._registers.OPCODE:02X}')
+                if self._invalid_opcode_mode == 0:
+                    # NOP mode: treat as 2-cycle implied NOP
+                    self._current_instruction = &MOS6502.implied
+                    self._next_instruction = &MOS6502.NOP
+                else:
+                    raise InvalidOPCode(
+                        f'Invalid OPCODE: 0x{self._registers.OPCODE:02X} '
+                        f'at 0x{self._registers.OPCODE_ADDR:04X}'
+                    )
 
         self._cycle_number = 0
         # We don't update the PC here, as we need to keep the registers consistent

--- a/src/py6502/sim/peripherals/apple1_display.pxd
+++ b/src/py6502/sim/peripherals/apple1_display.pxd
@@ -6,8 +6,8 @@ cdef class Apple1Display(Component):
     cdef TextDisplay _text_display
     cdef long _busy_remaining
 
-    cdef unsigned char read(self, unsigned short address)
-    cdef unsigned char write(self, unsigned short address, unsigned char data)
+    cdef unsigned char read(self, unsigned short address) except *
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
     cpdef list get_framebuffer(self)

--- a/src/py6502/sim/peripherals/apple1_display.pyx
+++ b/src/py6502/sim/peripherals/apple1_display.pyx
@@ -46,14 +46,14 @@ cdef class Apple1Display(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         if address == DSP:
             return DSP_BUSY if self._busy_remaining > 0 else 0x00
         return 0x00
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         cdef unsigned char stripped
         if address == DSP and self._busy_remaining <= 0:
             stripped = data & 0x7F

--- a/src/py6502/sim/peripherals/apple1_keyboard.pxd
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pxd
@@ -6,7 +6,7 @@ cdef class Apple1Keyboard(Component):
     cdef unsigned char _kbd_buffer_current_index
     cdef unsigned char _kbd_buffer_last_index
 
-    cdef unsigned char read(self, unsigned short address)
-    cdef unsigned char write(self, unsigned short address, unsigned char data)
+    cdef unsigned char read(self, unsigned short address) except *
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
     cpdef bint add_character_to_kb_buffer(self, unsigned char char_)
     cpdef void clear_kbd_buffer(self)

--- a/src/py6502/sim/peripherals/apple1_keyboard.pyx
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pyx
@@ -49,7 +49,7 @@ cdef class Apple1Keyboard(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address):
+    cdef unsigned char read(self, unsigned short address) except *:
         if address == KBDCR and self._kbd_buffer_last_index != (self._kbd_buffer_current_index + 1) % KBD_BUFFER_SIZE:
             return 0x80
         if address == KBD and self._kbd_buffer_last_index != (self._kbd_buffer_current_index + 1) % KBD_BUFFER_SIZE:
@@ -59,5 +59,5 @@ cdef class Apple1Keyboard(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data):
+    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
         return data

--- a/src/py6502/sim/system/system.pxd
+++ b/src/py6502/sim/system/system.pxd
@@ -13,8 +13,8 @@ cdef class System:
     cdef list _inputs
     cdef dict _memory_regions
 
-    cpdef void run_cycles(self, unsigned long cycles)
-    cpdef void run_for_microseconds(self, unsigned long microseconds)
+    cpdef void run_cycles(self, unsigned long cycles) except *
+    cpdef void run_for_microseconds(self, unsigned long microseconds) except *
     cpdef void reset(self)
     cpdef void load_binary(self, str region_name, unsigned int offset, bytes data)
     cpdef Registers get_registers(self)
@@ -23,6 +23,9 @@ cdef class System:
     cpdef void register_tick_hook(self, object component)
     cpdef unsigned char peek(self, unsigned short address)
     cpdef unsigned char poke(self, unsigned short address, unsigned char data)
+    cpdef bint is_mapped(self, unsigned short address)
+    cpdef void set_invalid_opcode_mode(self, unsigned char mode)
+    cpdef void set_unmapped_memory_mode(self, bint crash)
 
     cdef Component _instantiate_component(self, object spec)
     cdef void _wire_component(self, Component component, unsigned int address, str bus_name)

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -38,7 +38,7 @@ cdef class System:
         cpu_cls = _resolve_type(config.cpu.type)
         self._cpu = cpu_cls()
 
-        main_bus = BusController("main", self._cpu, True)
+        main_bus = BusController("main", self._cpu, False)
         self._buses["main"] = main_bus
 
         # --- Memory regions ---------------------------------------------
@@ -103,11 +103,11 @@ cdef class System:
     def cpu_hz(self):
         return self._cpu_hz
 
-    cpdef void run_cycles(self, unsigned long cycles):
+    cpdef void run_cycles(self, unsigned long cycles) except *:
         if cycles:
             (<BusController>self._buses["main"]).run_cycles(cycles)
 
-    cpdef void run_for_microseconds(self, unsigned long microseconds):
+    cpdef void run_for_microseconds(self, unsigned long microseconds) except *:
         if microseconds:
             (<BusController>self._buses["main"]).run_for_microseconds(microseconds, self._cpu_hz)
 
@@ -138,6 +138,15 @@ cdef class System:
 
     cpdef unsigned char poke(self, unsigned short address, unsigned char data):
         return (<BusController>self._buses["main"]).write(address, data)
+
+    cpdef bint is_mapped(self, unsigned short address):
+        return (<BusController>self._buses["main"]).is_mapped(address)
+
+    cpdef void set_invalid_opcode_mode(self, unsigned char mode):
+        self._cpu.set_invalid_opcode_mode(mode)
+
+    cpdef void set_unmapped_memory_mode(self, bint crash):
+        (<BusController>self._buses["main"]).set_unmapped_memory_mode(crash)
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/src/py6502/ui/app.py
+++ b/src/py6502/ui/app.py
@@ -11,6 +11,7 @@ from importlib import resources
 import dearpygui.dearpygui as dpg
 
 from py6502.sim.bus.emptyaddress import UnallocatedAddressError
+from py6502.sim.cpu.mos6502 import InvalidOPCode
 from py6502.sim.system import System
 from py6502.ui.utils.instructionmaps import INSTRUCTION_MAP_6502
 
@@ -56,6 +57,7 @@ class Py6502App:
         self._opcode_disasm = _build_opcode_disasm()
         self._mem_monitor_page = 0x00
         self._sim_running = True
+        self._sim_error: str | None = None
 
         self._build_texture_registry()
         self._build_menu_bar()
@@ -83,6 +85,21 @@ class Py6502App:
                 dpg.add_menu_item(label="Reset System", tag="ResetMenuItem", callback=self._reset_system)
                 dpg.add_separator(tag="FileMenuSeparator1")
                 dpg.add_menu_item(label="Exit", tag="ExitMenuItem", callback=dpg.stop_dearpygui)
+            with dpg.menu(label="Settings", tag="SettingsMenu"):
+                dpg.add_menu_item(
+                    label="Halt on invalid opcode",
+                    tag="SettingsInvalidOpcode",
+                    check=True,
+                    default_value=True,
+                    callback=self._on_invalid_opcode_toggle,
+                )
+                dpg.add_menu_item(
+                    label="Halt on unmapped memory",
+                    tag="SettingsUnmappedMemory",
+                    check=True,
+                    default_value=False,
+                    callback=self._on_unmapped_memory_toggle,
+                )
             with dpg.menu(label="Help"):
                 dpg.add_menu_item(label="About", callback=lambda: dpg.show_tool(dpg.mvTool_About))
 
@@ -141,6 +158,8 @@ class Py6502App:
                 dpg.add_text("Decode:")
                 dpg.add_text("", tag="reg_opcode_disasm")
 
+            dpg.add_text("", tag="sim_error_text", color=(255, 0, 0), show=False)
+
             dpg.add_separator()
             dpg.add_text("Memory Monitor", color=(255, 255, 0))
             with dpg.group(horizontal=True, horizontal_spacing=0):
@@ -173,7 +192,10 @@ class Py6502App:
             if self.system is not None:
                 if self._sim_running:
                     self._drain_keys_into_system()
-                    self.system.run_for_microseconds(FRAME_MICROSECONDS)
+                    try:
+                        self.system.run_for_microseconds(FRAME_MICROSECONDS)
+                    except (InvalidOPCode, UnallocatedAddressError) as exc:
+                        self._on_sim_error(exc)
                     dpg.set_value(TEXTURE_TAG, self.system.get_framebuffer())
                 self._refresh_debug_panels()
             dpg.render_dearpygui_frame()
@@ -209,9 +231,7 @@ class Py6502App:
         page = self._mem_monitor_page
         base = page << 8
         lines: list[str] = []
-        try:
-            self.system.peek(base)
-        except UnallocatedAddressError:
+        if not self.system.is_mapped(base):
             dpg.set_value("mem_monitor", f"{base:04X}: Unmapped memory range")
             dpg.configure_item("mem_monitor", color=(255, 0, 0))
             return
@@ -252,6 +272,22 @@ class Py6502App:
             else:
                 break
 
+    def _on_sim_error(self, exc: Exception) -> None:
+        self._sim_running = False
+        self._sim_error = str(exc)
+        dpg.set_value("sim_error_text", f"ERROR: {exc}")
+        dpg.configure_item("sim_error_text", show=True)
+        dpg.configure_item("play_button", enabled=False)
+        dpg.configure_item("pause_button", enabled=False)
+
+    def _on_invalid_opcode_toggle(self, sender, app_data, user_data) -> None:
+        if self.system is not None:
+            self.system.set_invalid_opcode_mode(1 if app_data else 0)
+
+    def _on_unmapped_memory_toggle(self, sender, app_data, user_data) -> None:
+        if self.system is not None:
+            self.system.set_unmapped_memory_mode(app_data)
+
     # ------------------------------------------------------------------
     # Callbacks
     # ------------------------------------------------------------------
@@ -271,6 +307,11 @@ class Py6502App:
             return
         self.system.reset()
         self._key_buffer.clear()
+        self._sim_error = None
+        dpg.configure_item("sim_error_text", show=False)
+        dpg.configure_item("play_button", enabled=True)
+        dpg.configure_item("pause_button", enabled=True)
+        self._play_handler()
         dpg.set_value(TEXTURE_TAG, self.system.get_framebuffer())
         self._refresh_debug_panels()
         dpg.focus_item(VIDEO_WINDOW_TAG)

--- a/tests/test_invalid_opcode.py
+++ b/tests/test_invalid_opcode.py
@@ -1,0 +1,84 @@
+"""
+Tests for invalid opcode handling (GH #25).
+
+Verifies NOP mode (skip and continue) and crash mode (raises
+InvalidOPCode from run_cycles).
+"""
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from py6502.sim.cpu.mos6502 import InvalidOPCode
+from py6502.sim.system import System
+
+
+MINIMAL_CONFIG = dedent("""\
+    version: 1
+    id: test_cpu
+    name: Test CPU
+    description: Minimal 64K RAM for testing.
+    cpu:
+      type: MOS6502
+      hz: 1000000
+    memory:
+      - name: RAM
+        start: 0x0000
+        size: 0x10000
+""")
+
+
+def _make_system(tmp_path, pc=0x0200):
+    """Build a minimal 64K-RAM system ready to execute at pc.
+
+    After from_yaml_file, send_reset sets _current_instruction to
+    load_op_code and INTERRUPT_TYPE to RESET. Clearing INTERRUPT_TYPE
+    and setting PC lets the first clock() call load the opcode at pc.
+    """
+    config = tmp_path / "test.yaml"
+    config.write_text(MINIMAL_CONFIG)
+    s = System.from_yaml_file(config)
+    regs = s.get_registers()
+    regs["PC"] = pc
+    regs["INTERRUPT_TYPE"] = 0
+    s.set_registers(regs)
+    return s
+
+
+@pytest.fixture
+def system(tmp_path):
+    return _make_system(tmp_path)
+
+
+def test_crash_mode_raises_on_invalid_opcode(system) -> None:
+    """Default crash mode raises InvalidOPCode during run_cycles."""
+    # 0x02 is an undefined 6502 opcode at 0x0200
+    system.load_binary("RAM", 0x0200, bytes([0x02]))
+
+    with pytest.raises(InvalidOPCode, match="0x02"):
+        system.run_cycles(10)
+
+
+def test_nop_mode_skips_invalid_opcode(system) -> None:
+    """NOP mode treats invalid opcodes as 2-cycle NOPs and continues."""
+    system.set_invalid_opcode_mode(0)  # NOP mode
+
+    # 0x02 (invalid) followed by NOP NOP
+    system.load_binary("RAM", 0x0200, bytes([0x02, 0xEA, 0xEA]))
+
+    system.run_cycles(10)
+
+    regs = system.get_registers()
+    assert regs["PC"] > 0x0202, (
+        f"expected PC past 0x0202, got 0x{regs['PC']:04X}"
+    )
+
+
+def test_crash_mode_includes_address_in_message(system) -> None:
+    """Crash mode error message includes both opcode and address."""
+    # JMP $0300, then invalid opcode at $0300
+    system.load_binary("RAM", 0x0200, bytes([0x4C, 0x00, 0x03]))
+    system.load_binary("RAM", 0x0300, bytes([0x02]))
+
+    with pytest.raises(InvalidOPCode, match="0x0300"):
+        system.run_cycles(20)

--- a/tests/test_unmapped_memory.py
+++ b/tests/test_unmapped_memory.py
@@ -1,0 +1,74 @@
+"""
+Tests for unmapped memory handling (GH #25).
+
+Verifies open-bus mode (returns last data bus value) and crash mode
+(raises UnallocatedAddressError from run_cycles). Also tests the
+is_mapped() UI query.
+"""
+from importlib import resources
+
+import pytest
+
+from py6502.sim.bus.emptyaddress import UnallocatedAddressError
+from py6502.sim.system import System
+
+
+APPLE1_PRESET = resources.files("py6502.sim.assets").joinpath("presets/apple1.yaml")
+
+
+@pytest.fixture
+def system():
+    return System.from_yaml_file(APPLE1_PRESET)
+
+
+def test_open_bus_returns_last_bus_value(system) -> None:
+    """In open-bus mode, reading unmapped memory returns the last bus value."""
+    # Write a known value to mapped RAM, then read unmapped memory
+    system.poke(0x0000, 0x42)
+    value = system.peek(0x0000)
+    assert value == 0x42
+
+    # 0x5000 is unmapped in the Apple I preset — should return last bus value
+    unmapped = system.peek(0x5000)
+    assert unmapped == 0x42, (
+        f"expected open-bus value 0x42, got 0x{unmapped:02X}"
+    )
+
+
+def test_crash_mode_raises_on_unmapped_read(system) -> None:
+    """Crash mode raises UnallocatedAddressError on unmapped access."""
+    system.set_unmapped_memory_mode(True)  # crash mode
+
+    with pytest.raises(UnallocatedAddressError, match="0x5000"):
+        system.peek(0x5000)
+
+
+def test_crash_mode_raises_during_run_cycles(system) -> None:
+    """Crash mode raises during sim execution if CPU reads unmapped memory."""
+    system.set_unmapped_memory_mode(True)
+
+    # JMP $5000 — CPU will try to fetch from unmapped address
+    system.load_binary("RAM", 0x0200, bytes([0x4C, 0x00, 0x50]))
+    regs = system.get_registers()
+    regs["PC"] = 0x0200
+    regs["INTERRUPT_TYPE"] = 0
+    system.set_registers(regs)
+
+    with pytest.raises(UnallocatedAddressError):
+        system.run_cycles(100)
+
+
+def test_is_mapped_returns_false_for_unmapped(system) -> None:
+    """is_mapped() returns False for addresses not backed by a component."""
+    assert system.is_mapped(0x0000) is True    # RAM
+    assert system.is_mapped(0xFF00) is True    # ROM
+    assert system.is_mapped(0xD010) is True    # Keyboard
+    assert system.is_mapped(0xD012) is True    # Display
+    assert system.is_mapped(0x5000) is False   # Unmapped
+    assert system.is_mapped(0x8000) is False   # Unmapped
+
+
+def test_open_bus_write_silently_drops(system) -> None:
+    """Writing to unmapped memory in open-bus mode does not crash."""
+    # Should not raise — writes are silently dropped
+    system.poke(0x5000, 0xFF)


### PR DESCRIPTION
## Summary
- Invalid opcodes are now user-configurable: **crash mode** (default) raises `InvalidOPCode` to the UI; **NOP mode** treats them as 2-cycle implied NOPs.
- Unmapped memory reads are user-configurable: **open-bus mode** (default) returns the last data bus value; **crash mode** raises `UnallocatedAddressError`.
- New Settings menu in the UI with "Halt on invalid opcode" and "Halt on unmapped memory" toggles.
- `EmptyAddress` open-bus reads use a `unsigned char*` pointer to `BusController._current_bus_data` — zero overhead on the hot path.
- `except *` added to the `Component.read()`/`write()` → `BusController` → `MOS6502.clock()` → `run_cycles()` chain so crash-mode exceptions propagate cleanly to the UI.
- `System.is_mapped()` query for the memory monitor (replaces exception-based unmapped detection).
- Roadmap synced with GitHub milestones (dropped 3 closed v0.1 issues, corrected titles).

## Why
The simulator previously crashed (or silently swallowed exceptions) on invalid opcodes and unmapped memory accesses. Real 6502 hardware has defined behavior for both cases — open bus for unmapped reads, and various responses to undefined opcodes. This PR makes the behavior configurable so users can choose between hardware-accurate graceful handling and strict error detection for debugging.

## Test plan
- [x] `pytest` — 23 tests pass (15 existing + 8 new)
- [x] `python -m py6502` — Apple I boots, wozmon runs normally
- [x] Settings > "Halt on invalid opcode" toggle works
- [x] Settings > "Halt on unmapped memory" toggle works
- [x] Error display in debug panel on crash, reset clears it
- [x] Memory monitor shows "Unmapped" for unmapped pages in both modes

## Closes
Closes #25