### PR TITLE
Restrict sim Python API surface to System only

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,8 +115,13 @@ cdef class Component:
     cdef void on_cycles_elapsed(self, unsigned long n):
         pass
 
-    cpdef unsigned int get_size(self): ...
-    cpdef str get_name(self): ...
+    cdef inline unsigned int get_size(self): ...
+    cdef inline str get_name(self): ...
+
+    # Optional overrides for display / input devices
+    cdef list get_framebuffer(self): ...    # default: None
+    cdef bint send_input(self, unsigned char char_): ...  # default: False
+    cdef void clear_input(self): ...        # default: no-op
 ```
 
 Every addressable thing in the simulator — RAM, ROM, peripherals, even
@@ -263,11 +268,13 @@ Peripherals follow a small contract:
 
 - **Must** override `cdef read(addr)` and `cdef write(addr, data)` for
   their register file.
-- **May** expose `get_framebuffer()` returning an RGBA buffer if they
-  are a display device. `System` uses this contract, *not* a hardcoded
-  class name.
-- **May** expose input methods (e.g. `add_character_to_kb_buffer`) for
-  keyboard-like devices.
+- **May** override `cdef list get_framebuffer(self)` (defined on
+  `Component`) returning an RGBA buffer if they are a display device.
+  `System.get_framebuffer()` calls through the base-class vtable.
+- **May** override `cdef bint send_input(self, unsigned char)` and
+  `cdef void clear_input(self)` for keyboard-like devices.
+  `System.send_key()` / `System.clear_input_buffer()` call through the
+  base-class vtable.
 - **May** override `cdef void bind(self, object system)` to subscribe
   to cycle-accounting ticks via `system.register_tick_hook(self)`.
   `Apple1Display` uses this to hold DSP bit 7 busy for one full NTSC frame
@@ -308,6 +315,11 @@ cpdef object get_framebuffer(self)
 cpdef void register_tick_hook(self, object component)
 cpdef unsigned char peek(self, unsigned short address)
 cpdef unsigned char poke(self, unsigned short address, unsigned char data)
+cpdef bint is_mapped(self, unsigned short address)
+cpdef void set_invalid_opcode_mode(self, unsigned char mode)
+cpdef void set_unmapped_memory_mode(self, bint crash)
+cpdef bint send_key(self, unsigned char char_)
+cpdef void clear_input_buffer(self)
 ```
 
 `peek`/`poke` forward to the `main` bus and exist for tests + debug
@@ -374,8 +386,8 @@ responsibilities:
 - Create the DearPyGui context, viewport, and menu bar on startup.
 - Load the Apple I preset via `System.from_yaml_file(...)` and assign
   the result to `self.system`.
-- Run a single per-frame loop that drains key presses into
-  `self.system.inputs[0]`, calls
+- Run a single per-frame loop that drains key presses via
+  `self.system.send_key(char)`, calls
   `self.system.run_for_microseconds(16667)`, pushes the framebuffer
   into the DearPyGui texture, and then calls
   `dpg.render_dearpygui_frame()`.

--- a/src/py6502/sim/bus/buscontroller.pxd
+++ b/src/py6502/sim/bus/buscontroller.pxd
@@ -27,20 +27,19 @@ cdef class BusController(Component):
     cdef EmptyAddress _empty_address
     cdef list _tick_hooks
 
-    cpdef void add_component(self, Component component, unsigned int address_start) except *
-    cpdef void register_tick_hook(self, object component)
+    cdef void add_component(self, Component component, unsigned int address_start) except *
+    cdef void register_tick_hook(self, object component)
 
-    cpdef void testme(self)
-    cpdef bint check_success(self)
+    cdef void clock(self) except *
+    cdef void run_cycles(self, unsigned long cycles) except *
+    cdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *
 
-    cpdef void clock(self) except *
-    cpdef void run_cycles(self, unsigned long cycles) except *
-    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *
+    cdef void send_reset(self)
 
-    cpdef void send_reset(self)
+    cdef Registers get_registers(self)
+    cdef void set_registers(self, Registers registers)
 
-    cpdef Registers get_registers(self)
-    cpdef void set_registers(self, Registers registers)
+    cdef bint is_mapped(self, unsigned short address)
+    cdef void set_unmapped_memory_mode(self, bint crash)
 
-    cpdef bint is_mapped(self, unsigned short address)
-    cpdef void set_unmapped_memory_mode(self, bint crash)
+    cdef tuple get_bus_values(self)

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -50,7 +50,7 @@ cdef class BusController(Component):
                 Py_DECREF(<Component>self._component_address_map[i].component)
                 self._component_address_map[i].component = NULL
 
-    cpdef void add_component(self, Component component, unsigned int address_start) except *:
+    cdef void add_component(self, Component component, unsigned int address_start) except *:
         """
         Add a component to the controller
 
@@ -84,7 +84,7 @@ cdef class BusController(Component):
             Py_INCREF(component)
             Py_DECREF(self._empty_address) # NEED TO decrement ref count to empty address
 
-    cpdef void register_tick_hook(self, object component):
+    cdef void register_tick_hook(self, object component):
         """
         Subscribe a component to the batch-end tick hook. After every
         run_cycles(N) call, the component's on_cycles_elapsed(N) cdef
@@ -92,17 +92,10 @@ cdef class BusController(Component):
         """
         self._tick_hooks.append(component)
 
-    cpdef void testme(self):
-        for _ in range(96_247_419):
-            self._processor.clock()
-
-    cpdef bint check_success(self):
-        return self.read(0x0200) == 0xF0
-
-    cpdef void clock(self) except *:
+    cdef void clock(self) except *:
         self._processor.clock()
 
-    cpdef void run_cycles(self, unsigned long cycles) except *:
+    cdef void run_cycles(self, unsigned long cycles) except *:
         cdef Py_ssize_t hook_idx
         cdef Py_ssize_t hook_count
         for _ in range(cycles):
@@ -111,28 +104,28 @@ cdef class BusController(Component):
         for hook_idx in range(hook_count):
             (<Component>self._tick_hooks[hook_idx]).on_cycles_elapsed(cycles)
 
-    cpdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *:
+    cdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *:
         cdef unsigned long cycles = (microseconds * cpu_hz) // 1000000
         if cycles:
             self.run_cycles(cycles)
 
-    cpdef void send_reset(self):
+    cdef void send_reset(self):
         self._processor.send_reset()
 
-    cpdef Registers get_registers(self):
+    cdef Registers get_registers(self):
         return self._processor.get_registers()
 
-    cpdef void set_registers(self, Registers registers):
+    cdef void set_registers(self, Registers registers):
         self._processor.set_registers(registers)
 
-    cpdef bint is_mapped(self, unsigned short address):
+    cdef bint is_mapped(self, unsigned short address):
         return (<Component>self._component_address_map[address].component
                 is not self._empty_address)
 
-    cpdef void set_unmapped_memory_mode(self, bint crash):
+    cdef void set_unmapped_memory_mode(self, bint crash):
         self._empty_address._raise_on_unmapped = crash
 
-    def get_bus_values(self):
+    cdef tuple get_bus_values(self):
         return (
             self._current_bus_address,
             self._current_bus_data,

--- a/src/py6502/sim/bus/component.pxd
+++ b/src/py6502/sim/bus/component.pxd
@@ -3,11 +3,14 @@ CYTHON BASE COMPONENT CLASS DECLARATIONS
 """
 
 cdef class Component:
-    cdef readonly unsigned int _size
-    cdef readonly str _name
+    cdef unsigned int _size
+    cdef str _name
     cdef inline str get_name(self)
     cdef inline unsigned int get_size(self)
     cdef unsigned char read(self, unsigned short address) except *
     cdef unsigned char write(self, unsigned short address, unsigned char data) except *
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
+    cdef list get_framebuffer(self)
+    cdef bint send_input(self, unsigned char char_)
+    cdef void clear_input(self)

--- a/src/py6502/sim/bus/component.pyx
+++ b/src/py6502/sim/bus/component.pyx
@@ -87,3 +87,15 @@ cdef class Component:
         this hook is cheap even when many components subscribe.
         """
         pass
+
+    cdef list get_framebuffer(self):
+        """Return an RGBA float list for display components. Default: None."""
+        return None
+
+    cdef bint send_input(self, unsigned char char_):
+        """Accept an input byte (e.g. a key press). Default: False (ignored)."""
+        return False
+
+    cdef void clear_input(self):
+        """Clear any pending input buffer. Default: no-op."""
+        pass

--- a/src/py6502/sim/bus/memory.pxd
+++ b/src/py6502/sim/bus/memory.pxd
@@ -6,3 +6,6 @@ from py6502.sim.bus.component cimport Component
 cdef class Memory(Component):
     cdef unsigned char* _data
     cdef bint _read_only
+
+    cdef void set_data(self, list data, int start_address) except *
+    cdef list get_data(self, int start_address, int size)

--- a/src/py6502/sim/bus/memory.pyx
+++ b/src/py6502/sim/bus/memory.pyx
@@ -52,7 +52,7 @@ cdef class Memory(Component):
 
         return data
 
-    def set_data(self, data: list[int], start_address: int=0x0000) -> None:
+    cdef void set_data(self, list data, int start_address) except *:
         """
         Writes data to memory starting at the specified address.
 
@@ -75,7 +75,7 @@ cdef class Memory(Component):
         for i, byte in enumerate(data):
             self._data[start_address + i] = <unsigned char>byte
 
-    def get_data(self, start_address: int, size: int) -> list[int]:
+    cdef list get_data(self, int start_address, int size):
         """
         Reads a block of data from memory.
 

--- a/src/py6502/sim/cpu/mos6502.pxd
+++ b/src/py6502/sim/cpu/mos6502.pxd
@@ -54,6 +54,7 @@ cdef class MOS6502:
     cdef void send_irq(self)
     cdef void send_nmi(self)
     cdef void load_op_code(self) except *
+    cdef void set_memory_bus(self, Component memory_bus)
     cdef void set_invalid_opcode_mode(self, unsigned char mode)
     cdef void clear_bcd_opcodes(self)
     cdef void set_bcd_opcodes(self)

--- a/src/py6502/sim/cpu/mos6502.pyx
+++ b/src/py6502/sim/cpu/mos6502.pyx
@@ -269,7 +269,7 @@ cdef class MOS6502:
     cdef void set_registers(self, Registers registers):
         self._registers = registers
 
-    def set_memory_bus(self, Component memory_bus):
+    cdef void set_memory_bus(self, Component memory_bus):
         self._memory_bus = memory_bus
 
     cdef void set_invalid_opcode_mode(self, unsigned char mode):

--- a/src/py6502/sim/graphics/textdisplay.pxd
+++ b/src/py6502/sim/graphics/textdisplay.pxd
@@ -6,7 +6,7 @@ cdef class Font:
     cdef unsigned char height
     cdef unsigned char set_size
 
-    cpdef void _create_character_set(self, char* filename) except *
+    cdef void _create_character_set(self, char* filename) except *
     cdef inline bint get_character_pixel(self, unsigned char character, unsigned char x, unsigned char y)
 
 cdef class TextDisplay:
@@ -28,7 +28,7 @@ cdef class TextDisplay:
     cdef unsigned char _character_max_rows
     cdef float[3][4] _colors #RGBA - 0 = background, 1 = foreground, 2 = cursor
 
-    cpdef list get_screen_buffer(self)
+    cdef list get_screen_buffer(self)
     cdef void set_cursor(self, unsigned char character, float[4] color, unsigned char cursor_mode)
     cdef void backspace(self)
     cdef void place_character(self, unsigned char character)

--- a/src/py6502/sim/graphics/textdisplay.pyx
+++ b/src/py6502/sim/graphics/textdisplay.pyx
@@ -9,7 +9,7 @@ cdef class Font:
         if self.character_set:
             free(self.character_set)
 
-    cpdef void _create_character_set(self, char* filename) except *:
+    cdef void _create_character_set(self, char* filename) except *:
         cdef FILE* cfile = fopen(filename, "rb")
         if cfile == NULL:
             raise FileNotFoundError(f"File {filename} not found")
@@ -68,7 +68,7 @@ cdef class TextDisplay:
         if self._cursor_pixel_map:
             free(self._cursor_pixel_map)
 
-    cpdef list get_screen_buffer(self):
+    cdef list get_screen_buffer(self):
         if self._cursor_mode == 1:
             self._cursor_blink_timer += 1
             if self._cursor_blink_timer == 30:

--- a/src/py6502/sim/peripherals/apple1_display.pxd
+++ b/src/py6502/sim/peripherals/apple1_display.pxd
@@ -10,4 +10,4 @@ cdef class Apple1Display(Component):
     cdef unsigned char write(self, unsigned short address, unsigned char data) except *
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
-    cpdef list get_framebuffer(self)
+    cdef list get_framebuffer(self)

--- a/src/py6502/sim/peripherals/apple1_display.pyx
+++ b/src/py6502/sim/peripherals/apple1_display.pyx
@@ -71,5 +71,5 @@ cdef class Apple1Display(Component):
         if self._busy_remaining > 0:
             self._busy_remaining -= <long>n
 
-    cpdef list get_framebuffer(self):
+    cdef list get_framebuffer(self):
         return self._text_display.get_screen_buffer()

--- a/src/py6502/sim/peripherals/apple1_keyboard.pxd
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pxd
@@ -8,5 +8,7 @@ cdef class Apple1Keyboard(Component):
 
     cdef unsigned char read(self, unsigned short address) except *
     cdef unsigned char write(self, unsigned short address, unsigned char data) except *
-    cpdef bint add_character_to_kb_buffer(self, unsigned char char_)
-    cpdef void clear_kbd_buffer(self)
+    cdef bint add_character_to_kb_buffer(self, unsigned char char_)
+    cdef void clear_kbd_buffer(self)
+    cdef bint send_input(self, unsigned char char_)
+    cdef void clear_input(self)

--- a/src/py6502/sim/peripherals/apple1_keyboard.pyx
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pyx
@@ -32,7 +32,7 @@ cdef class Apple1Keyboard(Component):
         if self._kbd_buffer is not NULL:
             free(self._kbd_buffer)
 
-    cpdef bint add_character_to_kb_buffer(self, unsigned char char_):
+    cdef bint add_character_to_kb_buffer(self, unsigned char char_):
         if self._kbd_buffer_current_index != self._kbd_buffer_last_index:
             # Apple I rubout: backspace → underscore.
             if char_ == 0x08:
@@ -43,9 +43,15 @@ cdef class Apple1Keyboard(Component):
             return True
         return False
 
-    cpdef void clear_kbd_buffer(self):
+    cdef void clear_kbd_buffer(self):
         self._kbd_buffer_current_index = KBD_BUFFER_SIZE - 1
         self._kbd_buffer_last_index = 0
+
+    cdef bint send_input(self, unsigned char char_):
+        return self.add_character_to_kb_buffer(char_)
+
+    cdef void clear_input(self):
+        self.clear_kbd_buffer()
 
     @boundscheck(False)
     @wraparound(False)

--- a/src/py6502/sim/system/system.pxd
+++ b/src/py6502/sim/system/system.pxd
@@ -26,6 +26,8 @@ cdef class System:
     cpdef bint is_mapped(self, unsigned short address)
     cpdef void set_invalid_opcode_mode(self, unsigned char mode)
     cpdef void set_unmapped_memory_mode(self, bint crash)
+    cpdef bint send_key(self, unsigned char char_)
+    cpdef void clear_input_buffer(self)
 
     cdef Component _instantiate_component(self, object spec)
     cdef void _wire_component(self, Component component, unsigned int address, str bus_name)

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -90,15 +90,6 @@ cdef class System:
         config = _loader_from_yaml_file(path)
         return cls(config, base_dir=path.parent)
 
-    # The property is defined Python-side so the UI can iterate it.
-    @property
-    def inputs(self):
-        return self._inputs
-
-    @property
-    def display(self):
-        return self._display
-
     @property
     def cpu_hz(self):
         return self._cpu_hz
@@ -128,7 +119,7 @@ cdef class System:
     cpdef object get_framebuffer(self):
         if self._display is None:
             return None
-        return self._display.get_framebuffer()
+        return (<Component>self._display).get_framebuffer()
 
     cpdef void register_tick_hook(self, object component):
         (<BusController>self._buses["main"]).register_tick_hook(component)
@@ -147,6 +138,15 @@ cdef class System:
 
     cpdef void set_unmapped_memory_mode(self, bint crash):
         (<BusController>self._buses["main"]).set_unmapped_memory_mode(crash)
+
+    cpdef bint send_key(self, unsigned char char_):
+        if not self._inputs:
+            return False
+        return (<Component>self._inputs[0]).send_input(char_)
+
+    cpdef void clear_input_buffer(self):
+        if self._inputs:
+            (<Component>self._inputs[0]).clear_input()
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/src/py6502/ui/CLAUDE.md
+++ b/src/py6502/ui/CLAUDE.md
@@ -21,7 +21,7 @@ py6502ui.py               LEGACY monolithic UI — do not port features into
 
 v0.1's `app.py` is deliberately minimal: it loads the Apple I preset via
 `System.from_yaml_file`, renders one 256×240 texture, pipes key presses
-into `system.inputs[0]`, and calls `system.run_for_microseconds(16667)`
+via `system.send_key(char)`, and calls `system.run_for_microseconds(16667)`
 once per frame. The system-selector dialog, debug panels, and memory
 monitor are the rest of the v0.1 scope and land on top of this shell.
 

--- a/src/py6502/ui/app.py
+++ b/src/py6502/ui/app.py
@@ -262,12 +262,8 @@ class Py6502App:
             self._update_memory_monitor()
 
     def _drain_keys_into_system(self) -> None:
-        if not self.system.inputs:
-            self._key_buffer.clear()
-            return
-        keyboard = self.system.inputs[0]
         while self._key_buffer:
-            if keyboard.add_character_to_kb_buffer(self._key_buffer[0]):
+            if self.system.send_key(self._key_buffer[0]):
                 self._key_buffer.pop(0)
             else:
                 break

--- a/src/py6502/ui/py6502ui.py
+++ b/src/py6502/ui/py6502ui.py
@@ -1,10 +1,10 @@
 # NOTE: This file is **reference material only**. It is the pre-restructure
 # monolithic UI, preserved as a feature-parity checklist while the new
 # Py6502App shell is being built out. It is not imported by the package
-# and does not need to stay runtime-correct — the imports and key call
-# sites below are updated to reflect the current architecture (split
-# Apple1 peripherals, Py6502App entry point) but the rest of the file
-# still wires the simulator by hand.
+# and does not run — the sim's Python API was reduced to System-only
+# (GH #37), so method calls on BusController, Memory, and peripheral
+# objects raise AttributeError. The imports still resolve; only the
+# method calls fail at runtime.
 import dearpygui.dearpygui as dpg
 from time import perf_counter, sleep
 from py6502.sim.peripherals import Apple1Display, Apple1Keyboard

--- a/tests/test_apple1_split.py
+++ b/tests/test_apple1_split.py
@@ -22,8 +22,7 @@ def apple1_system():
 
 
 def test_keyboard_fifo_and_kbdcr_clear_on_read(apple1_system) -> None:
-    keyboard = apple1_system.inputs[0]
-    assert keyboard.add_character_to_kb_buffer(ord("X"))
+    assert apple1_system.send_key(ord("X"))
 
     assert apple1_system.peek(0xD011) == 0x80
     assert apple1_system.peek(0xD010) == (ord("X") | 0x80)


### PR DESCRIPTION
## Summary
- Convert every `cpdef`/`def` method on non-System Cython classes to `cdef`
- Add `Component`-level virtual hooks (`get_framebuffer`, `send_input`, `clear_input`) for polymorphic dispatch through the base-class vtable
- Add `System.send_key()` and `System.clear_input_buffer()` to replace the old `system.inputs[0].add_character_to_kb_buffer()` pattern
- Remove `inputs` and `display` properties from System (replaced by the new methods)
- Remove `BusController.testme()` and `check_success()` test artifacts
- Declare previously-undeclared methods in `.pxd` files (`Memory.set_data`/`get_data`, `MOS6502.set_memory_bus`, `BusController.get_bus_values`)

## Why

The architecture intends System as the sole Python-facing API boundary — all other sim components should be Cython-only. Leaking `cpdef` methods on internal classes invites the frontend to bypass System, breaking the "one coarse call per frame" performance contract and coupling the UI to implementation details. This change enforces that boundary: the UI and tests now go exclusively through System, and internal component methods are invisible to Python.

## Test plan
- [x] `pip install -e .` — Cython extensions rebuild successfully
- [x] `pytest` — all 23 tests pass
- [x] Smoke test: `System.send_key()` works, old `inputs`/`display` properties raise `AttributeError`
- [x] `python -m py6502` — app boots, type in wozmon, confirm keyboard input works end-to-end

## Closes
Closes #37