### PR TITLE
Pace sim by wall-clock delta and show avg clock Hz in title

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,9 +62,7 @@ wrong here, every later release pays for it.
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
 - [#38](https://github.com/ricky-groenewald/py6502/issues/38) — Recover ~20% clock-loop throughput lost to except * overhead
-- [#41](https://github.com/ricky-groenewald/py6502/issues/41) — Configurable preset options in system selector
 - [#42](https://github.com/ricky-groenewald/py6502/issues/42) — Address-based binary loading in custom system builder
-- [#44](https://github.com/ricky-groenewald/py6502/issues/44) — Persist custom system configs as YAML for reuse and auto-load
 - [#45](https://github.com/ricky-groenewald/py6502/issues/45) — Decouple sim cycle pacing from UI frame rate
 
 **Explicit non-goals for v0.1.**

--- a/src/py6502/ui/CLAUDE.md
+++ b/src/py6502/ui/CLAUDE.md
@@ -36,18 +36,27 @@ The frame loop looks like this:
 
 ```python
 while dpg.is_dearpygui_running():
+    now = perf_counter()
+    dt = min(now - last_tick_time, MAX_CATCH_UP_SECONDS)
+    last_tick_time = now
     if self.system is not None:
         self._drain_keys_into_system()
-        self.system.run_for_microseconds(FRAME_MICROSECONDS)
+        self.system.run_for_microseconds(int(dt * 1_000_000))
         self._video.update_framebuffer(self.system.get_framebuffer())
         self._debug.refresh(self.system)
     dpg.render_dearpygui_frame()
 ```
 
+`dt` is wall-clock-driven, not a fixed per-frame constant: the sim
+advances by however much real time elapsed since the last tick, clamped
+to `MAX_CATCH_UP_SECONDS` so a paused dialog or a stalled frame can't
+trigger a catch-up burst. The sim's effective frequency therefore stays
+locked to `cpu_hz` regardless of the host display's refresh rate.
+
 That frame body is allowed to call **exactly one** of:
 
 - `System.run_cycles(n)`
-- `System.run_for_microseconds(µs)` (usually `16667` at 60 Hz / 1 MHz)
+- `System.run_for_microseconds(µs)` (µs derived from wall-clock dt)
 
 …followed by *reads* against `System.get_framebuffer()`,
 `System.get_registers()`, etc. Those reads are cheap: the framebuffer is a

--- a/src/py6502/ui/app.py
+++ b/src/py6502/ui/app.py
@@ -1,6 +1,9 @@
 """
 Py6502App — DearPyGui shell that boots a configurable System preset and
-renders video + debug panels at 60 Hz. See GH #8 for v0.1 UI scope.
+renders video + debug panels at the display's native refresh rate. The
+simulator is paced by wall-clock delta so its effective frequency stays
+locked to the configured ``cpu_hz`` regardless of UI frame rate. See
+GH #8 for v0.1 UI scope.
 """
 from pathlib import Path
 from time import perf_counter
@@ -22,7 +25,15 @@ from py6502.ui.windows.systemselector import SystemSelectorWindow
 from py6502.ui.windows.video import VideoWindow
 
 
-FRAME_MICROSECONDS = 16667
+MAX_CATCH_UP_SECONDS = 0.05
+
+
+def _format_hz(hz: float) -> str:
+    if hz >= 1_000_000:
+        return f"{hz / 1_000_000:.2f} MHz"
+    if hz >= 1_000:
+        return f"{hz / 1_000:.2f} kHz"
+    return f"{hz:.0f} Hz"
 
 
 class Py6502App:
@@ -154,25 +165,37 @@ class Py6502App:
     # ------------------------------------------------------------------
     def run(self) -> None:
         frame_count = 0
-        fps_timer = perf_counter()
+        cycles_accum = 0  # cycles *issued* to the sim — never CPU-bound in v0.1, so ≈ delivered
+        last_tick_time = perf_counter()
+        fps_timer = last_tick_time
         while dpg.is_dearpygui_running():
+            now = perf_counter()
+            dt = min(now - last_tick_time, MAX_CATCH_UP_SECONDS)
+            last_tick_time = now
             if self.system is not None:
                 if self._sim_running:
                     self._drain_keys_into_system()
+                    micros = int(dt * 1_000_000)
                     try:
-                        self.system.run_for_microseconds(FRAME_MICROSECONDS)
+                        self.system.run_for_microseconds(micros)
                     except (InvalidOPCode, UnallocatedAddressError) as exc:
                         self._on_sim_error(exc)
+                    else:
+                        cycles_accum += (micros * self.system.cpu_hz) // 1_000_000
                     self._video.update_framebuffer(self.system.get_framebuffer())
                 self._debug.refresh(self.system)
             dpg.render_dearpygui_frame()
             frame_count += 1
-            now = perf_counter()
-            if now - fps_timer >= 2.0:
-                fps = frame_count / (now - fps_timer)
+            elapsed = now - fps_timer
+            if elapsed >= 2.0:
+                fps = frame_count / elapsed
+                avg_hz = cycles_accum / elapsed
                 suffix = f" - {self._system_name}" if self._system_name else ""
-                dpg.set_viewport_title(f"Py6502 - {fps:.0f} FPS{suffix}")
+                dpg.set_viewport_title(
+                    f"Py6502 - {fps:.0f} FPS - {_format_hz(avg_hz)}{suffix}"
+                )
                 frame_count = 0
+                cycles_accum = 0
                 fps_timer = now
         dpg.destroy_context()
 


### PR DESCRIPTION
## Summary
- Replace the hard-coded `FRAME_MICROSECONDS = 16667` with wall-clock-delta pacing in `Py6502App.run()`, clamped to 50 ms to prevent catch-up bursts after dialogs or pauses.
- Add an average clock-frequency readout to the viewport title next to the existing FPS counter, piggybacking on the same 2-second timer. No sim-side changes — the UI already knows how many cycles it issues per frame.
- Sync v0.1 roadmap open-issue list (drop #41, #44 which closed with PR #46).

## Why
The frame loop was pacing the simulator by frame count under the assumption that DearPyGui ticks at 60 Hz. It doesn't — it ticks at the display's refresh rate, so a 120 Hz monitor ran the sim at 2 MHz and a 30 Hz display at 500 kHz. The sim's `run_for_microseconds` was correct; only the UI's µs argument was wrong.

Wall-clock delta pacing is the simplest shape that keeps the sim locked to `cpu_hz` without introducing `time.sleep()` (low resolution, stalls render) or a deficit accumulator (no fixed-timestep requirement — the 6502 advances cleanly from any whole-cycle boundary). The 50 ms clamp prevents post-dialog / post-pause burst catch-up while keeping perceived cadence smooth. Input ordering (drain → sim → present) is preserved so v0.2 NES controller input can slot in at the same callsite.

## Test plan
- [x] `python -m py6502`, boot Apple I preset, title reads ~`60 FPS - 1.00 MHz - Apple I`
- [x] MHz readout stays ~1.00 across 60 Hz / 120 Hz / 30 Hz displays (before the fix it tracked FPS/60)
- [x] Open \"New System...\" dialog for a few seconds, close it — no fast-forward burst
- [x] Pause via debug panel — title shows \"0 Hz\"; resume — back to ~1.00 MHz without a burst
- [x] Run wozmon interactively for ~30 s — input feel unchanged

## Closes
Closes #45