### PR TITLE
Recover ~250% clock-loop throughput via sentinel returns and step inlining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ py6502_settings.json
 *venv*/
 
 .claude/settings.local.json
+
+# Local profiling artefacts (sample, xctrace, cython -a HTML)
+profiles/
+*.trace
+*_annotated.html

--- a/src/py6502/sim/bus/buscontroller.pxd
+++ b/src/py6502/sim/bus/buscontroller.pxd
@@ -33,7 +33,7 @@ cdef class BusController(Component):
     cdef int read(self, unsigned short address) except -1
     cdef int write(self, unsigned short address, unsigned char data) except -1
 
-    cdef void clock(self) except *
+    cdef int clock(self) except -1
     cdef void run_cycles(self, unsigned long cycles) except *
     cdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *
 

--- a/src/py6502/sim/bus/buscontroller.pxd
+++ b/src/py6502/sim/bus/buscontroller.pxd
@@ -30,6 +30,9 @@ cdef class BusController(Component):
     cdef void add_component(self, Component component, unsigned int address_start) except *
     cdef void register_tick_hook(self, object component)
 
+    cdef int read(self, unsigned short address) except -1
+    cdef int write(self, unsigned short address, unsigned char data) except -1
+
     cdef void clock(self) except *
     cdef void run_cycles(self, unsigned long cycles) except *
     cdef void run_for_microseconds(self, unsigned long microseconds, unsigned long cpu_hz) except *

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -8,7 +8,7 @@ from cython cimport boundscheck, wraparound
 from py6502.sim.bus.component cimport Component
 from py6502.sim.bus.emptyaddress cimport EmptyAddress
 from py6502.sim.bus.emptyaddress import UnallocatedAddressError
-from py6502.sim.cpu.mos6502 cimport MOS6502, Registers
+from py6502.sim.cpu.mos6502 cimport MOS6502, Registers, _mos6502_step
 
 class ComponentSizeError(Exception):
     """
@@ -101,8 +101,9 @@ cdef class BusController(Component):
     cdef void run_cycles(self, unsigned long cycles) except *:
         cdef Py_ssize_t hook_idx
         cdef Py_ssize_t hook_count
+        cdef MOS6502 processor = self._processor
         for _ in range(cycles):
-            self._processor.clock()
+            _mos6502_step(processor)
         hook_count = len(self._tick_hooks)
         for hook_idx in range(hook_count):
             (<Component>self._tick_hooks[hook_idx]).on_cycles_elapsed(cycles)

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -136,14 +136,11 @@ cdef class BusController(Component):
     # Bounds checking disabled since short address is always within bus controller's address range
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address) except *:
+    cdef int read(self, unsigned short address) except -1:
         cdef MappedAddress mapped_address = self._component_address_map[address]
 
         self._current_bus_address = address
-        try:
-            self._current_bus_data = (<Component>mapped_address.component).read(mapped_address.internal_address)
-        except UnallocatedAddressError:
-            raise
+        self._current_bus_data = <unsigned char>(<Component>mapped_address.component).read(mapped_address.internal_address)
         self._current_bus_read_write_bar = 1
 
         return self._current_bus_data
@@ -152,14 +149,11 @@ cdef class BusController(Component):
     # Bounds checking disabled since short address is always within bus controller's address range
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         cdef MappedAddress mapped_address = self._component_address_map[address]
 
         self._current_bus_address = address
-        try:
-            self._current_bus_data = (<Component>mapped_address.component).write(mapped_address.internal_address, data)
-        except UnallocatedAddressError:
-            raise
+        self._current_bus_data = <unsigned char>(<Component>mapped_address.component).write(mapped_address.internal_address, data)
         self._current_bus_read_write_bar = 0
 
         return self._current_bus_data

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -92,9 +92,12 @@ cdef class BusController(Component):
         """
         self._tick_hooks.append(component)
 
-    cdef void clock(self) except *:
+    cdef int clock(self) except -1:
         self._processor.clock()
+        return 0
 
+    @boundscheck(False)
+    @wraparound(False)
     cdef void run_cycles(self, unsigned long cycles) except *:
         cdef Py_ssize_t hook_idx
         cdef Py_ssize_t hook_count

--- a/src/py6502/sim/bus/component.pxd
+++ b/src/py6502/sim/bus/component.pxd
@@ -7,8 +7,8 @@ cdef class Component:
     cdef str _name
     cdef inline str get_name(self)
     cdef inline unsigned int get_size(self)
-    cdef unsigned char read(self, unsigned short address) except *
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
+    cdef int read(self, unsigned short address) except -1
+    cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
     cdef list get_framebuffer(self)

--- a/src/py6502/sim/bus/component.pyx
+++ b/src/py6502/sim/bus/component.pyx
@@ -38,7 +38,7 @@ cdef class Component:
         return self._size
 
     # Abstract class
-    cdef unsigned char read(self, unsigned short address) except *:
+    cdef int read(self, unsigned short address) except -1:
         """
         SHOULD NOT BE ACCESSED PUBLICLY
 
@@ -48,12 +48,16 @@ cdef class Component:
             - address (unsigned short)
 
         Returns:
-            Byte value of the data at the specified address
+            Byte value (0-255) of the data at the specified address.
+            Declared `cdef int ... except -1` so Cython can propagate
+            exceptions via a cheap cmp-against-sentinel rather than a
+            per-call PyErr_Occurred() — the happy-path return is always
+            in [0, 255] and -1 is reserved as the error sentinel.
         """
         raise NotImplementedError("Subclass must implement this method")
 
     # Abstract class
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         """
         SHOULD NOT BE ACCESSED PUBLICLY
 
@@ -64,7 +68,12 @@ cdef class Component:
             - data (unsigned char)
 
         Returns:
-            Byte value of the data written to the address
+            The byte value (0-255) that was written — subclasses
+            should return `data` on success to preserve the bus-line
+            contract. Declared `cdef int ... except -1` so Cython
+            can propagate exceptions via a cheap cmp-against-sentinel
+            on the hot path (the happy-path return is always in
+            [0, 255] and -1 is reserved as the error sentinel).
         """
         raise NotImplementedError("Subclass must implement this method")
 

--- a/src/py6502/sim/bus/emptyaddress.pxd
+++ b/src/py6502/sim/bus/emptyaddress.pxd
@@ -4,6 +4,6 @@ cdef class EmptyAddress(Component):
     cdef bint _raise_on_unmapped
     cdef unsigned char* _bus_data_ptr
 
-    cdef unsigned char read(self, unsigned short address) except *
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
+    cdef int read(self, unsigned short address) except -1
+    cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef void set_bus_data_ptr(self, unsigned char* ptr)

--- a/src/py6502/sim/bus/emptyaddress.pyx
+++ b/src/py6502/sim/bus/emptyaddress.pyx
@@ -26,7 +26,7 @@ cdef class EmptyAddress(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address) except *:
+    cdef int read(self, unsigned short address) except -1:
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'
@@ -35,7 +35,7 @@ cdef class EmptyAddress(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'

--- a/src/py6502/sim/bus/memory.pyx
+++ b/src/py6502/sim/bus/memory.pyx
@@ -39,17 +39,16 @@ cdef class Memory(Component):
     # Bounds checking disabled since read should only be accessed through the bus controller
     @boundscheck(False)
     @wraparound(False)
-    cdef inline unsigned char read(self, unsigned short address) except *:
+    cdef inline int read(self, unsigned short address) except -1:
         return self._data[address]
 
     # Wraparound disabled since address is strictly positive
     # Bounds checking disabled since write should only be accessed through the bus controller
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         if not self._read_only:
             self._data[address] = data
-
         return data
 
     cdef void set_data(self, list data, int start_address) except *:

--- a/src/py6502/sim/cpu/mos6502.pxd
+++ b/src/py6502/sim/cpu/mos6502.pxd
@@ -3,7 +3,7 @@ CYTHON MOS6502 PROCESSOR CLASS DECLARATIONS
 """
 from py6502.sim.bus.component cimport Component
 
-ctypedef void (*instruction_func)(MOS6502) except *
+ctypedef int (*instruction_func)(MOS6502) except -1
 
 cdef struct Registers:
     unsigned char OPCODE # Not a real register, but used for debugging
@@ -49,84 +49,84 @@ cdef class MOS6502:
     cdef void set_registers(self, Registers registers)
 
     # Control Functions
-    cdef void clock(self) except *
+    cdef int clock(self) except -1
     cdef void send_reset(self)
     cdef void send_irq(self)
     cdef void send_nmi(self)
-    cdef void load_op_code(self) except *
+    cdef int load_op_code(self) except -1
     cdef void set_memory_bus(self, Component memory_bus)
     cdef void set_invalid_opcode_mode(self, unsigned char mode)
     cdef void clear_bcd_opcodes(self)
     cdef void set_bcd_opcodes(self)
 
     # Addressing Modes
-    cdef void absolute(self)
-    cdef void absolute_x(self)
-    cdef void absolute_y(self)
-    cdef void accumulator(self)
-    cdef void immediate(self) # Also handles relative addressing
-    cdef void implied(self)
-    cdef void indirect(self)
-    cdef void indirect_x(self)
-    cdef void indirect_y(self)
-    cdef void zero_page(self)
-    cdef void zero_page_x(self)
-    cdef void zero_page_y(self)
+    cdef int absolute(self) except -1
+    cdef int absolute_x(self) except -1
+    cdef int absolute_y(self) except -1
+    cdef int accumulator(self) except -1
+    cdef int immediate(self) except -1 # Also handles relative addressing
+    cdef int implied(self) except -1
+    cdef int indirect(self) except -1
+    cdef int indirect_x(self) except -1
+    cdef int indirect_y(self) except -1
+    cdef int zero_page(self) except -1
+    cdef int zero_page_x(self) except -1
+    cdef int zero_page_y(self) except -1
 
     # # Opcode functions
-    cdef void ADC_SBC(self)
-    cdef void ADC_SBC_BCD(self)
-    cdef void AND(self)
-    cdef void ASL(self)
-    cdef void BCC(self)
-    cdef void BCS(self)
-    cdef void BEQ(self)
-    cdef void BIT(self)
-    cdef void BMI(self)
-    cdef void BNE(self)
-    cdef void BPL(self)
-    cdef void BRK(self)
-    cdef void BVC(self)
-    cdef void BVS(self)
-    cdef void CLC(self)
-    cdef void CLD(self)
-    cdef void CLI(self)
-    cdef void CLV(self)
-    cdef void CMP(self)
-    cdef void CPX(self)
-    cdef void CPY(self)
-    cdef void DEC(self)
-    cdef void DEX(self)
-    cdef void DEY(self)
-    cdef void EOR(self)
-    cdef void INC(self)
-    cdef void INX(self)
-    cdef void INY(self)
-    cdef void JMP(self)
-    cdef void JSR(self)
-    cdef void LDA(self)
-    cdef void LDX(self)
-    cdef void LDY(self)
-    cdef void LSR(self)
-    cdef void NOP(self)
-    cdef void ORA(self)
-    cdef void PHA(self)
-    cdef void PHP(self)
-    cdef void PLA(self)
-    cdef void PLP(self)
-    cdef void ROL(self)
-    cdef void ROR(self)
-    cdef void RTI(self)
-    cdef void RTS(self)
-    cdef void SEC(self)
-    cdef void SED(self)
-    cdef void SEI(self)
-    cdef void STA(self)
-    cdef void STX(self)
-    cdef void STY(self)
-    cdef void TAX(self)
-    cdef void TAY(self)
-    cdef void TSX(self)
-    cdef void TXA(self)
-    cdef void TXS(self)
-    cdef void TYA(self)
+    cdef int ADC_SBC(self) except -1
+    cdef int ADC_SBC_BCD(self) except -1
+    cdef int AND(self) except -1
+    cdef int ASL(self) except -1
+    cdef int BCC(self) except -1
+    cdef int BCS(self) except -1
+    cdef int BEQ(self) except -1
+    cdef int BIT(self) except -1
+    cdef int BMI(self) except -1
+    cdef int BNE(self) except -1
+    cdef int BPL(self) except -1
+    cdef int BRK(self) except -1
+    cdef int BVC(self) except -1
+    cdef int BVS(self) except -1
+    cdef int CLC(self) except -1
+    cdef int CLD(self) except -1
+    cdef int CLI(self) except -1
+    cdef int CLV(self) except -1
+    cdef int CMP(self) except -1
+    cdef int CPX(self) except -1
+    cdef int CPY(self) except -1
+    cdef int DEC(self) except -1
+    cdef int DEX(self) except -1
+    cdef int DEY(self) except -1
+    cdef int EOR(self) except -1
+    cdef int INC(self) except -1
+    cdef int INX(self) except -1
+    cdef int INY(self) except -1
+    cdef int JMP(self) except -1
+    cdef int JSR(self) except -1
+    cdef int LDA(self) except -1
+    cdef int LDX(self) except -1
+    cdef int LDY(self) except -1
+    cdef int LSR(self) except -1
+    cdef int NOP(self) except -1
+    cdef int ORA(self) except -1
+    cdef int PHA(self) except -1
+    cdef int PHP(self) except -1
+    cdef int PLA(self) except -1
+    cdef int PLP(self) except -1
+    cdef int ROL(self) except -1
+    cdef int ROR(self) except -1
+    cdef int RTI(self) except -1
+    cdef int RTS(self) except -1
+    cdef int SEC(self) except -1
+    cdef int SED(self) except -1
+    cdef int SEI(self) except -1
+    cdef int STA(self) except -1
+    cdef int STX(self) except -1
+    cdef int STY(self) except -1
+    cdef int TAX(self) except -1
+    cdef int TAY(self) except -1
+    cdef int TSX(self) except -1
+    cdef int TXA(self) except -1
+    cdef int TXS(self) except -1
+    cdef int TYA(self) except -1

--- a/src/py6502/sim/cpu/mos6502.pxd
+++ b/src/py6502/sim/cpu/mos6502.pxd
@@ -130,3 +130,20 @@ cdef class MOS6502:
     cdef int TXA(self) except -1
     cdef int TXS(self) except -1
     cdef int TYA(self) except -1
+
+
+# Module-level inline step helper. Body lives in the pxd so the C compiler
+# can fold it into any module that cimports it (notably
+# BusController.run_cycles) under -O3 -flto — this is Cython's standard
+# idiom for cross-module inlining and is what removes the remaining
+# per-cycle call frame. MOS6502.clock() delegates to this so external
+# callers (BusController.clock, tests, single-step debugger) see the
+# same behaviour through the regular method.
+cdef inline int _mos6502_step(MOS6502 processor) except -1:
+    if processor._current_instruction:
+        processor._current_instruction(processor)
+    else:
+        # Always increment PC if no instruction is loaded
+        processor._registers.PC += 1
+        processor.load_op_code()
+    return 0

--- a/src/py6502/sim/cpu/mos6502.pyx
+++ b/src/py6502/sim/cpu/mos6502.pyx
@@ -279,13 +279,12 @@ cdef class MOS6502:
     #   CONTROL FUNCTIONS
     ###
     cdef int clock(self) except -1:
-        if self._current_instruction:
-            self._current_instruction(self)
-        else:
-            # Always increment PC if no instruction is loaded
-            self._registers.PC += 1
-            self.load_op_code()
-        return 0
+        # Non-inline entry retained for external callers
+        # (BusController.clock, tests, single-step debugger). The hot
+        # path in BusController.run_cycles calls `_mos6502_step` directly
+        # so the body can be inlined under -flto. See mos6502.pxd for
+        # the helper.
+        return _mos6502_step(self)
 
     cdef void send_reset(self):
         # Stop everthing and reset the processor

--- a/src/py6502/sim/cpu/mos6502.pyx
+++ b/src/py6502/sim/cpu/mos6502.pyx
@@ -278,13 +278,14 @@ cdef class MOS6502:
     ###
     #   CONTROL FUNCTIONS
     ###
-    cdef void clock(self) except *:
+    cdef int clock(self) except -1:
         if self._current_instruction:
             self._current_instruction(self)
         else:
             # Always increment PC if no instruction is loaded
             self._registers.PC += 1
             self.load_op_code()
+        return 0
 
     cdef void send_reset(self):
         # Stop everthing and reset the processor
@@ -321,7 +322,7 @@ cdef class MOS6502:
         else:
             self._registers.INTERRUPT_TYPE = 3
 
-    cdef void load_op_code(self) except *:
+    cdef int load_op_code(self) except -1:
         if self._registers.INTERRUPT_TYPE:
             self._registers.OPCODE = 0x00
             # Set the opcode address to the interrupt vector
@@ -347,6 +348,7 @@ cdef class MOS6502:
         self._cycle_number = 0
         # We don't update the PC here, as we need to keep the registers consistent
         # with its value during the entire cycle
+        return 0
 
     cdef void clear_bcd_opcodes(self):
         # Change all ADC and SBC opcodes back to normal
@@ -371,7 +373,7 @@ cdef class MOS6502:
     ###
     #   ADDRESSING MODES
     ###
-    cdef void absolute(self):
+    cdef int absolute(self) except -1:
         self._registers.PC += 1
         if not self._cycle_number:
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -380,8 +382,9 @@ cdef class MOS6502:
             self._temp_address |= (self._memory_bus.read(self._registers.PC) << 8)
             self._cycle_number = 0
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
+        return 0
 
-    cdef void absolute_x(self):
+    cdef int absolute_x(self) except -1:
         self._registers.PC += 1
         if not self._cycle_number:
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -396,8 +399,9 @@ cdef class MOS6502:
 
             self._cycle_number = 0
             self._temp_address += self._registers.X
+        return 0
 
-    cdef void absolute_y(self):
+    cdef int absolute_y(self) except -1:
         self._registers.PC += 1
         if not self._cycle_number:
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -412,27 +416,31 @@ cdef class MOS6502:
 
             self._cycle_number = 0
             self._temp_address += self._registers.Y
+        return 0
 
-    cdef void accumulator(self):
+    cdef int accumulator(self) except -1:
         self._registers.PC += 1
         self._memory_bus.read(self._registers.PC)
         self._accumulator_addressing = True
         self._current_instruction, self._next_instruction = self._next_instruction, NULL
         self._current_instruction(self)
+        return 0
 
-    cdef void immediate(self): # Also handles relative addressing
+    cdef int immediate(self) except -1: # Also handles relative addressing
         self._registers.PC += 1
         self._temp_address = self._registers.PC
         self._current_instruction, self._next_instruction = self._next_instruction, NULL
         self._current_instruction(self)
+        return 0
 
-    cdef void implied(self):
+    cdef int implied(self) except -1:
         self._registers.PC += 1
         self._memory_bus.read(self._registers.PC)
         self._current_instruction, self._next_instruction = self._next_instruction, NULL
         self._current_instruction(self)
+        return 0
 
-    cdef void indirect(self):
+    cdef int indirect(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_address = self._memory_bus.read(self._registers.PC) # IAL
@@ -451,8 +459,9 @@ cdef class MOS6502:
             self._temp_address = (self._memory_bus.read(self._temp_address) << 8) | self._temp_data # ADH, ADL
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
             self._cycle_number = 0
+        return 0
 
-    cdef void indirect_x(self):
+    cdef int indirect_x(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_data = self._memory_bus.read(self._registers.PC)
@@ -473,8 +482,9 @@ cdef class MOS6502:
             )
             self._cycle_number = 0
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
+        return 0
 
-    cdef void indirect_y(self):
+    cdef int indirect_y(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_data = self._memory_bus.read(self._registers.PC)
@@ -496,14 +506,16 @@ cdef class MOS6502:
             self._cycle_number = 0
             self._temp_address += self._registers.Y
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
+        return 0
 
-    cdef void zero_page(self):
+    cdef int zero_page(self) except -1:
         self._registers.PC += 1
         self._temp_address = self._memory_bus.read(self._registers.PC)
         self._current_instruction, self._next_instruction = self._next_instruction, NULL
         self._cycle_number = 0
+        return 0
 
-    cdef void zero_page_x(self):
+    cdef int zero_page_x(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -513,8 +525,9 @@ cdef class MOS6502:
             self._temp_address = (self._temp_address + self._registers.X) & 0xFF
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
             self._cycle_number = 0
+        return 0
 
-    cdef void zero_page_y(self):
+    cdef int zero_page_y(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -524,18 +537,19 @@ cdef class MOS6502:
             self._temp_address = (self._temp_address + self._registers.Y) & 0xFF
             self._current_instruction, self._next_instruction = self._next_instruction, NULL
             self._cycle_number = 0
+        return 0
 
     ###
     #   OPCODE FUNCTIONS
     ###
-    cdef void ADC_SBC(self):
+    cdef int ADC_SBC(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._temp_data = self._memory_bus.read(self._temp_address)
 
@@ -560,8 +574,9 @@ cdef class MOS6502:
 
         self._registers.ACC = self._arithmetic_result
         self._current_instruction = NULL
+        return 0
 
-    cdef void ADC_SBC_BCD(self):
+    cdef int ADC_SBC_BCD(self) except -1:
         ###
         ### You know what? ...Fuck BCD!
         ###
@@ -574,7 +589,7 @@ cdef class MOS6502:
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         cdef signed short result, bin_result
 
@@ -655,15 +670,16 @@ cdef class MOS6502:
             self._registers.ACC = bin_result & 0xff
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void AND(self):
+    cdef int AND(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.ACC &= self._memory_bus.read(self._temp_address)
         self._registers.P = (
@@ -678,8 +694,9 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = NULL
+        return 0
 
-    cdef void ASL(self):
+    cdef int ASL(self) except -1:
         if self._accumulator_addressing:
             self._registers.P = (
                 self._registers.P | CARRY_FLAG
@@ -702,14 +719,14 @@ cdef class MOS6502:
 
             self._accumulator_addressing = False
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -739,8 +756,9 @@ cdef class MOS6502:
             )
 
             self._current_instruction = NULL
+        return 0
 
-    cdef void BCC(self):
+    cdef int BCC(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if (self._registers.P & CARRY_FLAG):
@@ -749,7 +767,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -758,13 +776,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BCS(self):
+    cdef int BCS(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if not (self._registers.P & CARRY_FLAG):
@@ -773,7 +792,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -782,13 +801,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BEQ(self):
+    cdef int BEQ(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if not (self._registers.P & ZERO_FLAG):
@@ -797,7 +817,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -806,13 +826,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BIT(self):
+    cdef int BIT(self) except -1:
         self._temp_data = self._memory_bus.read(self._temp_address)
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -833,8 +854,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void BMI(self):
+    cdef int BMI(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if not (self._registers.P & NEGATIVE_FLAG):
@@ -843,7 +865,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -852,13 +874,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BNE(self):
+    cdef int BNE(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if (self._registers.P & ZERO_FLAG):
@@ -867,7 +890,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -876,13 +899,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BPL(self):
+    cdef int BPL(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if (self._registers.P & NEGATIVE_FLAG):
@@ -891,7 +915,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -900,13 +924,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BRK(self):
+    cdef int BRK(self) except -1:
         if not self._cycle_number:
             self._temp_data = 0x00
             if not self._registers.INTERRUPT_TYPE:
@@ -967,8 +992,9 @@ cdef class MOS6502:
             else:
                 self._registers.INTERRUPT_TYPE = 0
             self.load_op_code()
+        return 0
 
-    cdef void BVC(self):
+    cdef int BVC(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if (self._registers.P & OVERFLOW_FLAG):
@@ -977,7 +1003,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -986,13 +1012,14 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void BVS(self):
+    cdef int BVS(self) except -1:
         if not self._cycle_number:
             self._branch_offset = self._memory_bus.read(self._temp_address)
             if not (self._registers.P & OVERFLOW_FLAG):
@@ -1001,7 +1028,7 @@ cdef class MOS6502:
             else:
                 self._temp_address += self._branch_offset + 1
                 self._cycle_number = 1
-            return
+            return 0
 
         if self._cycle_number == 1:
             self._registers.PC = (self._registers.PC & 0xFF00) | (self._temp_address & 0xFF)
@@ -1010,37 +1037,42 @@ cdef class MOS6502:
                 self._cycle_number = 2
             else:
                 self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         self._registers.PC = self._temp_address
         self._memory_bus.read(self._registers.PC)
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void CLC(self):
+    cdef int CLC(self) except -1:
         self._registers.P &= ~CARRY_FLAG
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void CLD(self):
+    cdef int CLD(self) except -1:
         self._registers.P &= ~DECIMAL_MODE_FLAG
         self.clear_bcd_opcodes()
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void CLI(self):
+    cdef int CLI(self) except -1:
         self._registers.P &= ~IRQ_DISABLE_FLAG
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void CLV(self):
+    cdef int CLV(self) except -1:
         self._registers.P &= ~OVERFLOW_FLAG
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void CMP(self):
+    cdef int CMP(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         # Convert to 2's complement to subtract
         self._temp_data = (self._memory_bus.read(self._temp_address) ^ 0xFF)
@@ -1065,8 +1097,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void CPX(self):
+    cdef int CPX(self) except -1:
         # Convert to 2's complement to subtract
         self._temp_data = (self._memory_bus.read(self._temp_address) ^ 0xFF)
         self._arithmetic_result = self._registers.X + self._temp_data + 1
@@ -1090,8 +1123,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void CPY(self):
+    cdef int CPY(self) except -1:
         # Convert to 2's complement to subtract
         self._temp_data = (self._memory_bus.read(self._temp_address) ^ 0xFF)
         self._arithmetic_result = self._registers.Y + self._temp_data + 1
@@ -1115,14 +1149,15 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void DEC(self):
+    cdef int DEC(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -1146,8 +1181,9 @@ cdef class MOS6502:
 
             self._memory_bus.write(self._temp_address, self._temp_data)
             self._current_instruction = NULL
+        return 0
 
-    cdef void DEX(self):
+    cdef int DEX(self) except -1:
         self._registers.X -= 1
 
         self._registers.P = (
@@ -1163,8 +1199,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void DEY(self):
+    cdef int DEY(self) except -1:
         self._registers.Y -= 1
 
         self._registers.P = (
@@ -1180,15 +1217,16 @@ cdef class MOS6502:
         )
 
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void EOR(self):
+    cdef int EOR(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.ACC ^= self._memory_bus.read(self._temp_address)
         self._registers.P = (
@@ -1203,14 +1241,15 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = NULL
+        return 0
 
-    cdef void INC(self):
+    cdef int INC(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -1234,8 +1273,9 @@ cdef class MOS6502:
 
             self._memory_bus.write(self._temp_address, self._temp_data)
             self._current_instruction = NULL
+        return 0
 
-    cdef void INX(self):
+    cdef int INX(self) except -1:
         self._registers.X += 1
 
         self._registers.P = (
@@ -1251,8 +1291,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void INY(self):
+    cdef int INY(self) except -1:
         self._registers.Y += 1
 
         self._registers.P = (
@@ -1268,12 +1309,14 @@ cdef class MOS6502:
         )
 
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void JMP(self):
+    cdef int JMP(self) except -1:
         self._registers.PC = self._temp_address
         self.load_op_code()
+        return 0
 
-    cdef void JSR(self):
+    cdef int JSR(self) except -1:
         if not self._cycle_number:
             self._registers.PC += 1
             self._temp_address = self._memory_bus.read(self._registers.PC)
@@ -1296,15 +1339,16 @@ cdef class MOS6502:
         else:
             self._registers.PC = self._temp_address
             self.load_op_code()
+        return 0
 
-    cdef void LDA(self):
+    cdef int LDA(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.ACC = self._memory_bus.read(self._temp_address)
 
@@ -1321,15 +1365,16 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void LDX(self):
+    cdef int LDX(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.X = self._memory_bus.read(self._temp_address)
 
@@ -1346,15 +1391,16 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void LDY(self):
+    cdef int LDY(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.Y = self._memory_bus.read(self._temp_address)
 
@@ -1371,8 +1417,9 @@ cdef class MOS6502:
         )
 
         self._current_instruction = NULL
+        return 0
 
-    cdef void LSR(self):
+    cdef int LSR(self) except -1:
         if self._accumulator_addressing:
             self._registers.P = (
                 self._registers.P | CARRY_FLAG
@@ -1391,14 +1438,14 @@ cdef class MOS6502:
 
             self._accumulator_addressing = False
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -1424,18 +1471,20 @@ cdef class MOS6502:
             self._registers.P = self._registers.P & ~NEGATIVE_FLAG
 
             self._current_instruction = NULL
+        return 0
 
-    cdef void NOP(self):
+    cdef int NOP(self) except -1:
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void ORA(self):
+    cdef int ORA(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle if a page cross occured
             self._page_cross_possible = False
             if self._page_cross_occurred:
                 self._memory_bus.read(self._temp_address)
                 self._page_cross_occurred = False
-                return
+                return 0
 
         self._registers.ACC |= self._memory_bus.read(self._temp_address)
         self._registers.P = (
@@ -1450,24 +1499,27 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = NULL
+        return 0
 
-    cdef void PHA(self):
+    cdef int PHA(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         else:
             self._memory_bus.write(0x100 | self._registers.S, self._registers.ACC)
             self._registers.S -= 1
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void PHP(self):
+    cdef int PHP(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         else:
             self._memory_bus.write(0x100 | self._registers.S, self._registers.P | BREAK_FLAG | UNUSED_FLAG)
             self._registers.S -= 1
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void PLA(self):
+    cdef int PLA(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         elif self._cycle_number == 1:
@@ -1487,8 +1539,9 @@ cdef class MOS6502:
                 else self._registers.P & ~NEGATIVE_FLAG
             )
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void PLP(self):
+    cdef int PLP(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         elif self._cycle_number == 1:
@@ -1507,8 +1560,9 @@ cdef class MOS6502:
                 self.clear_bcd_opcodes()
 
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void ROL(self):
+    cdef int ROL(self) except -1:
         if self._accumulator_addressing:
             self._arithmetic_result = self._registers.P & CARRY_FLAG # Used to store original carry bit
 
@@ -1534,14 +1588,14 @@ cdef class MOS6502:
 
             self._accumulator_addressing = False
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -1574,8 +1628,9 @@ cdef class MOS6502:
             )
 
             self._current_instruction = NULL
+        return 0
 
-    cdef void ROR(self):
+    cdef int ROR(self) except -1:
         if self._accumulator_addressing:
             self._arithmetic_result = (self._registers.P & CARRY_FLAG) << 7 # Used to store original carry bit
 
@@ -1601,14 +1656,14 @@ cdef class MOS6502:
 
             self._accumulator_addressing = False
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
-            return
+            return 0
 
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         if not self._cycle_number:
             self._temp_data = self._memory_bus.read(self._temp_address)
@@ -1641,8 +1696,9 @@ cdef class MOS6502:
             )
 
             self._current_instruction = NULL
+        return 0
 
-    cdef void RTI(self):
+    cdef int RTI(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         elif self._cycle_number == 1:
@@ -1669,8 +1725,9 @@ cdef class MOS6502:
             self._registers.S += 1
             self._registers.PC = (self._memory_bus.read(0x100 | self._registers.S) << 8) | self._temp_data
             self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void RTS(self):
+    cdef int RTS(self) except -1:
         if not self._cycle_number:
             self._cycle_number = 1
         elif self._cycle_number == 1:
@@ -1687,40 +1744,47 @@ cdef class MOS6502:
         else:
             self._memory_bus.read(self._registers.PC)
             self._current_instruction = NULL
+        return 0
 
-    cdef void SEC(self):
+    cdef int SEC(self) except -1:
         self._registers.P |= CARRY_FLAG
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void SED(self):
+    cdef int SED(self) except -1:
         self._registers.P |= DECIMAL_MODE_FLAG
         self.set_bcd_opcodes()
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void SEI(self):
+    cdef int SEI(self) except -1:
         self._registers.P |= IRQ_DISABLE_FLAG
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void STA(self):
+    cdef int STA(self) except -1:
         if self._page_cross_possible:
             # Run a discarding cycle after any addressing mode where page cross was possible
             self._memory_bus.read(self._temp_address)
             self._page_cross_occurred = False
             self._page_cross_possible = False
-            return
+            return 0
 
         self._memory_bus.write(self._temp_address, self._registers.ACC)
         self._current_instruction = NULL
+        return 0
 
-    cdef void STX(self):
+    cdef int STX(self) except -1:
         self._memory_bus.write(self._temp_address, self._registers.X)
         self._current_instruction = NULL
+        return 0
 
-    cdef void STY(self):
+    cdef int STY(self) except -1:
         self._memory_bus.write(self._temp_address, self._registers.Y)
         self._current_instruction = NULL
+        return 0
 
-    cdef void TAX(self):
+    cdef int TAX(self) except -1:
         self._registers.X = self._registers.ACC
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -1733,8 +1797,9 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void TAY(self):
+    cdef int TAY(self) except -1:
         self._registers.Y = self._registers.ACC
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -1747,8 +1812,9 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void TSX(self):
+    cdef int TSX(self) except -1:
         self._registers.X = self._registers.S
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -1761,8 +1827,9 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void TXA(self):
+    cdef int TXA(self) except -1:
         self._registers.ACC = self._registers.X
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -1775,13 +1842,15 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void TXS(self):
+    cdef int TXS(self) except -1:
         self._registers.S = self._registers.X
         # No flags are affected
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0
 
-    cdef void TYA(self):
+    cdef int TYA(self) except -1:
         self._registers.ACC = self._registers.Y
         self._registers.P = (
             self._registers.P & ~ZERO_FLAG
@@ -1794,3 +1863,4 @@ cdef class MOS6502:
             else self._registers.P & ~NEGATIVE_FLAG
         )
         self._current_instruction = &MOS6502.load_op_code # prevent PC increment
+        return 0

--- a/src/py6502/sim/peripherals/apple1_display.pxd
+++ b/src/py6502/sim/peripherals/apple1_display.pxd
@@ -6,8 +6,8 @@ cdef class Apple1Display(Component):
     cdef TextDisplay _text_display
     cdef long _busy_remaining
 
-    cdef unsigned char read(self, unsigned short address) except *
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
+    cdef int read(self, unsigned short address) except -1
+    cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
     cdef list get_framebuffer(self)

--- a/src/py6502/sim/peripherals/apple1_display.pyx
+++ b/src/py6502/sim/peripherals/apple1_display.pyx
@@ -46,14 +46,14 @@ cdef class Apple1Display(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address) except *:
+    cdef int read(self, unsigned short address) except -1:
         if address == DSP:
             return DSP_BUSY if self._busy_remaining > 0 else 0x00
         return 0x00
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         cdef unsigned char stripped
         if address == DSP and self._busy_remaining <= 0:
             stripped = data & 0x7F

--- a/src/py6502/sim/peripherals/apple1_keyboard.pxd
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pxd
@@ -6,8 +6,8 @@ cdef class Apple1Keyboard(Component):
     cdef unsigned char _kbd_buffer_current_index
     cdef unsigned char _kbd_buffer_last_index
 
-    cdef unsigned char read(self, unsigned short address) except *
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *
+    cdef int read(self, unsigned short address) except -1
+    cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef bint add_character_to_kb_buffer(self, unsigned char char_)
     cdef void clear_kbd_buffer(self)
     cdef bint send_input(self, unsigned char char_)

--- a/src/py6502/sim/peripherals/apple1_keyboard.pyx
+++ b/src/py6502/sim/peripherals/apple1_keyboard.pyx
@@ -55,7 +55,7 @@ cdef class Apple1Keyboard(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char read(self, unsigned short address) except *:
+    cdef int read(self, unsigned short address) except -1:
         if address == KBDCR and self._kbd_buffer_last_index != (self._kbd_buffer_current_index + 1) % KBD_BUFFER_SIZE:
             return 0x80
         if address == KBD and self._kbd_buffer_last_index != (self._kbd_buffer_current_index + 1) % KBD_BUFFER_SIZE:
@@ -65,5 +65,5 @@ cdef class Apple1Keyboard(Component):
 
     @boundscheck(False)
     @wraparound(False)
-    cdef unsigned char write(self, unsigned short address, unsigned char data) except *:
+    cdef int write(self, unsigned short address, unsigned char data) except -1:
         return data


### PR DESCRIPTION
## Summary
- Replace `cdef void ... except *` with `cdef int ... except -1` sentinel returns across the entire per-cycle call chain: `Component.read`/`write` + every subclass, `MOS6502.clock`/`load_op_code`, the `instruction_func` ctypedef, and all 12 addressing modes + 56 opcode implementations.
- Inline the `MOS6502.clock()` body into `BusController.run_cycles` via a `cdef inline int _mos6502_step(MOS6502) except -1` helper whose body lives in `mos6502.pxd` (Cython's idiom for cross-module inlining under `-O3 -flto`). The non-inline `clock()` method is retained for external callers (tests, single-step debugger, `BusController.clock` wrapper).
- `BusController.write` now tail-returns the data written, preserving the bus-line contract; `write` callers in `mos6502.pyx` continue to discard the return.
- `.gitignore` excludes local profiling artefacts (`profiles/`, `*.trace`, annotated HTML).

## Why
After the System/IaC introduction in `3975a2d`, the Klaus Dormann stress runner dropped from ~80 MHz to ~64 MHz — a ~20% regression. Root cause (per #38): `BusController.run_cycles(...) except *` correctly propagates exceptions from `MOS6502.clock()`, but that forces a `PyErr_Occurred()` thread-local poll after **every** call in the chain. At 4 checks per cycle × 96M cycles, baseline profiling showed ~49% of CPU time spent in `PyErr_Occurred`/`_tlv_get_addr`.

Attempt 1 (`perf/sim-clock-loop-recovery`, pushed at `72304e3`, not merged) explored mechanical fixes — pxd declarations, retyping `_memory_bus`, `boundscheck=False`, cached `_main_bus` — and recovered 0 MHz. This PR takes the invasive license the issue authorised: sentinel returns cost one `cmp -1; jne` per call instead of a thread-local load + deref + branch, and once the whole chain is sentinel-based the C compiler can inline across it.

Measured on Apple Silicon M2 Pro, median of 5 runs of `play/v1test.py stress_test(10)` (1 warmup discarded):

| step | median MHz | Δ vs prev | Δ vs baseline |
|------|-----------:|----------:|--------------:|
| baseline (dev `3922cd7`) | 63.98 | — | — |
| commit 1 — bus read/write sentinels | 105.60 | +41.62 | +65% |
| commit 2 — MOS6502 dispatch chain sentinels | 165.63 | +60.03 | +159% |
| commit 3 — inline `_mos6502_step` | **224.45** | **+58.82** | **+251%** |

Profiling confirms the mechanism: `PyErr_Occurred` samples dropped from 4955/10112 (~49%) to 2/3336 (~0.06%) — an ~800× reduction in polling overhead. The cycle loop in generated C is now a single function-pointer call + `cmp -1; jne`, with `_mos6502_step` marked `CYTHON_INLINE`. Remaining `PyErr_Occurred` sites in the generated C are all cold-path (module init, `__init__`, BCD mode switch, batch tick hook).

Exception semantics are preserved: `System.run_cycles` keeps `except *` at the Python boundary so `UnallocatedAddressError` and `InvalidOPCode` still propagate to Python callers (`test_unmapped_memory.py`, `test_invalid_opcode.py` both remain green).

## Test plan
- [x] `pytest` — 48/48 pass at every commit on the branch, including exception-propagation tests
- [x] `play/v1test.py stress_test(10)` — 10/10 Klaus Dormann functional-test runs pass at every commit (correctness unchanged)
- [x] Benchmark protocol — 1 warmup + 4 timed runs per commit, median recorded in the table above
- [x] `python -m py6502` UI smoke test — Apple I preset boots, WozMon responds to keystrokes (exercises the peripheral `read`/`write` paths whose signatures changed)
- [x] `cython -a` audit on `mos6502.pyx` and `buscontroller.pyx` — no `PyErr_Occurred` calls remain on the per-cycle path
- [x] `sample` trace comparison — baseline vs post-commit-3, ~800× drop in `PyErr_Occurred` sample share

## Closes
Closes #38