### PR TITLE
Sync v0.1 open-issue list in ROADMAP with GitHub

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,9 +61,10 @@ wrong here, every later release pays for it.
 
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
-- [#38](https://github.com/ricky-groenewald/py6502/issues/38) — Recover ~20% clock-loop throughput lost to except * overhead
 - [#42](https://github.com/ricky-groenewald/py6502/issues/42) — Address-based binary loading in custom system builder
-- [#45](https://github.com/ricky-groenewald/py6502/issues/45) — Decouple sim cycle pacing from UI frame rate
+- [#49](https://github.com/ricky-groenewald/py6502/issues/49) — Apple1Display DSP busy timer hardcoded to 1 MHz
+- [#50](https://github.com/ricky-groenewald/py6502/issues/50) — Wire Klaus + Bruce Clark tests into pytest with perf reporting
+- [#51](https://github.com/ricky-groenewald/py6502/issues/51) — Binary source picker: filesystem vs bundled assets, backed by an asset manifest
 
 **Explicit non-goals for v0.1.**
 


### PR DESCRIPTION
## Summary
- Drop closed #38 and #45 from the v0.1 open-issue list.
- Add newly-opened #49, #50, #51 to the v0.1 open-issue list.
- v0.2 and v0.3 lists already in sync; not touched.

## Why
The `/roadmap pull` reconciliation revealed drift on v0.1 only: two items
had been closed upstream (the `except *` throughput recovery and the
sim/UI pacing decouple) while three new ones were filed today (Apple1
DSP busy timer at non-1-MHz, Klaus + Bruce Clark pytest wiring, and the
bundled-assets binary picker). Keeping this list current is the whole
point of the ROADMAP — if it drifts, it stops being useful context for
future scope discussions.

Prose is intentionally untouched; `pull` mode only rebuilds the bullet
lists. The v0.1 scope paragraph still reads cleanly against the new
issues, though #49 and #51 are new surface area not explicitly named in
the prose — worth a follow-up prose refresh if you want, but not
required for the sync.

## Test plan
- [x] `docs/ROADMAP.md` renders cleanly on GitHub with the updated list.
- [x] Every issue link resolves to an OPEN issue in the v0.1 milestone.