### PR TITLE
Derive Apple1Display DSP busy timer from configured CPU Hz

### DIFF
--- a/src/py6502/sim/peripherals/apple1_display.pxd
+++ b/src/py6502/sim/peripherals/apple1_display.pxd
@@ -5,6 +5,7 @@ from py6502.sim.graphics.textdisplay cimport TextDisplay
 cdef class Apple1Display(Component):
     cdef TextDisplay _text_display
     cdef long _busy_remaining
+    cdef long _busy_cycles
 
     cdef int read(self, unsigned short address) except -1
     cdef int write(self, unsigned short address, unsigned char data) except -1

--- a/src/py6502/sim/peripherals/apple1_display.pyx
+++ b/src/py6502/sim/peripherals/apple1_display.pyx
@@ -6,10 +6,14 @@ Register file (component-relative):
     offset 1 — DSPCR ($D013 on the bus)
 
 DSP bit 7 is the "display busy" flag. On real hardware it stays high
-for approximately one NTSC frame (≈ 16667 cycles at 1 MHz) after a DSP
-write, which is what throttles wozmon's output to ~60 chars/second. We
-preserve that timing with a simple countdown that is serviced from the
-batch-end tick hook — no per-cycle work on the CPU hot path.
+for approximately one NTSC frame after a DSP write, which is what
+throttles wozmon's output to ~60 chars/second. We preserve that timing
+with a simple countdown that is serviced from the batch-end tick hook —
+no per-cycle work on the CPU hot path. The countdown's initial value
+is computed once at ``bind()`` time from the configured CPU frequency
+(``round(cpu_hz / 60)`` — 60 Hz NTSC is hardcoded; PAL is not yet
+plumbed through), so the timing follows ``cpu_hz`` rather than being
+baked in at 1 MHz.
 """
 from cython cimport boundscheck, wraparound
 from importlib import resources
@@ -24,7 +28,7 @@ cdef float[4] FG_COLOR = [0x66 / 255.0, 1.0, 0x66 / 255.0, 1.0]
 DEF DSP = 0x0000
 DEF DSPCR = 0x0001
 DEF DSP_BUSY = 0x80
-DEF DSP_BUSY_CYCLES = 16667  # 1 NTSC frame at 1 MHz
+DEF DSP_BUSY_FRAME_HZ = 60  # NTSC; PAL (50 Hz) not yet plumbed through
 
 
 cdef class Apple1Display(Component):
@@ -40,9 +44,11 @@ cdef class Apple1Display(Component):
         self._text_display.clear_screen()
 
         self._busy_remaining = 0
+        self._busy_cycles = 0
 
     cdef void bind(self, object system):
         system.register_tick_hook(self)
+        self._busy_cycles = round(system.cpu_hz / DSP_BUSY_FRAME_HZ)
 
     @boundscheck(False)
     @wraparound(False)
@@ -64,7 +70,7 @@ cdef class Apple1Display(Component):
             elif stripped >= 0x60:
                 # Apple 1 charset quirk: 0x60-0x7F render as 0x40-0x5F.
                 self._text_display.place_character(stripped - 0x20)
-            self._busy_remaining = DSP_BUSY_CYCLES
+            self._busy_remaining = self._busy_cycles
         return data
 
     cdef void on_cycles_elapsed(self, unsigned long n):

--- a/tests/test_apple1_split.py
+++ b/tests/test_apple1_split.py
@@ -6,11 +6,12 @@ the Python surface deliberately stops at ``System``. These tests drive
 the peripherals through ``System.peek`` / ``System.poke``, which is the
 same path any debug panel or future test harness uses.
 """
+import dataclasses
 from importlib import resources
 
 import pytest
 
-from py6502.sim.system import System
+from py6502.sim.system import CpuSpec, System, from_yaml_file
 
 
 APPLE1_PRESET = resources.files("py6502.sim.assets").joinpath("presets/apple1.yaml")
@@ -59,6 +60,30 @@ def test_dsp_busy_timing_via_system_run_cycles() -> None:
     assert system.peek(0xD012) == 0x80
 
     system.run_cycles(16666)
+    assert system.peek(0xD012) == 0x80
+
+    system.run_cycles(1)
+    assert system.peek(0xD012) == 0x00
+
+
+def test_dsp_busy_timing_scales_with_cpu_hz() -> None:
+    """
+    The DSP busy window is derived from the configured CPU frequency at
+    bind time — ``round(cpu_hz / 60)`` cycles per NTSC frame — rather
+    than being baked in at 1 MHz. At 2 MHz one frame is 33 333 cycles,
+    so the flag must still be busy at cycle 33 332 and cleared at 33 333.
+    """
+    base_config = from_yaml_file(APPLE1_PRESET)
+    fast_config = dataclasses.replace(
+        base_config, cpu=CpuSpec(type="MOS6502", hz=2_000_000)
+    )
+    system = System(fast_config)
+
+    assert system.peek(0xD012) == 0x00
+    system.poke(0xD012, ord("A"))
+    assert system.peek(0xD012) == 0x80
+
+    system.run_cycles(33332)
     assert system.peek(0xD012) == 0x80
 
     system.run_cycles(1)


### PR DESCRIPTION
## Summary
- Replace the compile-time `DEF DSP_BUSY_CYCLES = 16667` in `Apple1Display` with a value derived from `system.cpu_hz` at `bind()` time (`round(cpu_hz / 60)` — one NTSC frame expressed in CPU cycles).
- Add a named `DEF DSP_BUSY_FRAME_HZ = 60` constant so the NTSC assumption is explicit in source; PAL (50 Hz) is flagged as deferred rather than plumbed through.
- Store the computed window as a new `cdef long _busy_cycles` instance field; the hot-path `write` and `on_cycles_elapsed` stay pure-Cython and untouched (still one decrement per batch).
- Add a 2 MHz regression test (`test_dsp_busy_timing_scales_with_cpu_hz`) that asserts the busy flag stays high for exactly 33 333 cycles at `cpu_hz = 2_000_000`; the existing 1 MHz test is unchanged.

## Why
The DSP bit-7 "busy" window models real hardware pinning the flag high for roughly one NTSC frame after a write — ≈ 16.67 ms of scan time, not 16 667 CPU cycles. At the Apple 1 preset's `cpu.hz = 1_000_000` those happen to be the same number, so the bug only surfaces when a user builds a `SystemConfig` with any other `cpu_hz` (overclocked Apple 1, or any future machine reusing the component). With the busy count no longer tied to the clock, the window ends too early (character throttling disappears, wozmon floods) or too late (perceived slowdown). The fix is to compute the cycle count once at `bind()` from the configured frequency — cheap, one-shot, and unchanged on the per-cycle hot path.

Works regardless of entry point: both `System.run_cycles(n)` and `System.run_for_microseconds(us)` resolve to CPU cycles at the configured Hz before reaching `Component.on_cycles_elapsed`, so `round(cpu_hz / 60)` is the correct constant in both cases.

## Test plan
- [x] `pytest tests/test_apple1_split.py -v` — 5/5 pass, including the new `test_dsp_busy_timing_scales_with_cpu_hz` at 2 MHz (busy at 33 332 cycles, cleared at 33 333).
- [x] `pytest` — full suite, 49/49 pass; `test_system_smoke.py` (drives 60 Hz batches via `run_for_microseconds(16667)`) is the canary that write-path throttling still works and stays green.
- [x] Manual smoke: `python -m py6502`, load Apple 1 preset, run wozmon — display cadence should be identical to current behaviour since the default preset stays at `cpu.hz = 1_000_000`.

## Closes
Closes #49