### PR TITLE
Add top-level binaries config with address-based loading

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,7 +64,6 @@ wrong here, every later release pays for it.
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
 - [#42](https://github.com/ricky-groenewald/py6502/issues/42) — Address-based binary loading in custom system builder
-- [#49](https://github.com/ricky-groenewald/py6502/issues/49) — Apple1Display DSP busy timer hardcoded to 1 MHz
 - [#51](https://github.com/ricky-groenewald/py6502/issues/51) — Binary source picker: filesystem vs bundled assets, backed by an asset manifest
 
 **Explicit non-goals for v0.1.**

--- a/docs/SYSTEM_CONFIG.md
+++ b/docs/SYSTEM_CONFIG.md
@@ -28,7 +28,7 @@ generate from a UI.
    those names to the actual Cython classes. Users can only instantiate
    components py6502 has explicitly registered.
 3. **ROM data lives in external files, never inline.** Configs stay
-   human-readable; ROMs stay binary. See [§4 Source URIs](#4-source-uris).
+   human-readable; ROMs stay binary. See [§5 Binaries](#5-binaries).
 4. **Typed externally, flat internally.** The schema has distinct
    `display` / `inputs` / `audio` / `other` sections so configs are
    self-documenting and the UI has clean hooks; internally `System`
@@ -64,7 +64,10 @@ memory:
     start: 0xFF00
     size: 0x0100
     read_only: true
-    source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+
+binaries:
+  - source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+    address: 0xFF00
 
 display:
   type: Apple1Display
@@ -76,8 +79,8 @@ inputs:
 ```
 
 That's the whole file. Everything else is optional. py6502 fills in
-defaults for `buses`, `audio`, `other`, `author`, `tags`, and each
-component's `bus` field.
+defaults for `buses`, `audio`, `other`, `binaries`, `author`, `tags`,
+and each component's `bus` field.
 
 ---
 
@@ -98,6 +101,7 @@ component's `bus` field.
 | `audio`       | ComponentSpec    | no       | `null`  | Exactly one audio device or none. (v0.2)                                  |
 | `other`       | list[CompSpec]   | no       | `[]`    | Misc components (timers, RTCs, etc.).                                     |
 | `buses`       | dict[str,BusSpec]| no       | see §3.3| Bus topology. v0.1 defaults to a single `main` bus.                       |
+| `binaries`    | list[BinarySrc]  | no       | `[]`    | Binary payloads loaded into memory at boot. See [§5](#5-binaries).        |
 | `author`      | string           | no       | `null`  | Credit field for user-shared configs.                                     |
 | `tags`        | list[string]     | no       | `[]`    | Free-form tags for UI filtering.                                          |
 | `options`     | list[OptionSpec] | no       | `[]`    | User-selectable preset options. See [§3.8](#38-options).                  |
@@ -111,7 +115,7 @@ cpu:
 ```
 
 The CPU type string resolves through the same registry as components
-([§5](#5-the-component-registry)). `hz` is the **master clock** —
+([§6](#6-the-component-registry)). `hz` is the **master clock** —
 per-bus dividers are applied on top of this in v0.2.
 
 v0.1 registered CPU types:
@@ -159,8 +163,6 @@ memory:
     size: 0x1000            # required, bytes (int or hex literal)
     read_only: false        # optional, default false
     bus: main               # optional, default "main"
-    source: null            # optional, default null → zero-initialized
-    load_offset: 0          # optional, where in the region to load `source`
 ```
 
 **Fields:**
@@ -170,10 +172,8 @@ memory:
 | `name`        | string | yes      | —        | Must be unique within this config. Referenced by `load_binary`.       |
 | `start`       | int    | yes      | —        | Bus address where the region begins. Hex literals (`0x0000`) allowed. |
 | `size`        | int    | yes      | —        | Number of bytes. Must satisfy `start + size <= 2**address_width`.     |
-| `read_only`   | bool   | no       | `false`  | If `true`, writes are silently dropped (ROM semantics).               |
+| `read_only`   | bool   | no       | `false`  | If `true`, runtime writes are silently dropped (ROM semantics).       |
 | `bus`         | string | no       | `"main"` | Which bus the region sits on.                                         |
-| `source`      | URI    | no       | `null`   | See [§4 Source URIs](#4-source-uris). `null` → zero-initialized.      |
-| `load_offset` | int    | no       | `0`      | Byte offset within the region where `source` bytes start loading.     |
 
 **Validation:**
 
@@ -181,8 +181,12 @@ memory:
 - Regions on the same bus must not overlap.
 - `start` must be bus-aligned to a byte boundary (implicit — addresses
   are bytes).
-- If `source` is provided, the source file must fit inside `size -
-  load_offset`; excess bytes fail the load.
+
+Memory regions are always zero-initialised at construction. To preload
+ROM or program data, declare a [binary source](#5-binaries) that targets
+the region's address range. Binaries may span multiple contiguous
+regions, and `read_only: true` regions accept the initial payload —
+the ROM guard only applies to runtime `write()` through the bus.
 
 ### 3.5 `display`
 
@@ -291,8 +295,9 @@ values must be one of the declared choices, `int` / `hex` values honour
 
 ## 4. Source URIs
 
-The `source:` field on a memory region is a **URI string** with one of
-two schemes:
+A **source URI** points at a blob of bytes on disk or inside a package.
+It is used by the [`binaries:`](#5-binaries) section. URIs have one of
+two schemes; no others are supported.
 
 ### `resource:`
 
@@ -326,7 +331,45 @@ boundary is local filesystem only.
 
 ---
 
-## 5. The component registry
+## 5. Binaries
+
+The top-level `binaries:` list describes payloads loaded into memory at
+`System.__init__` time, before reset. Each entry is independent of any
+single memory region — a binary is addressed by **absolute bus address**
+and may span multiple contiguous memory regions.
+
+```yaml
+binaries:
+  - source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+    address: 0xFF00
+  - source: file:./demos/game.bin
+    address: 0x0200
+    bus: main               # optional, default "main"
+```
+
+**Fields:**
+
+| Field      | Type   | Required | Default  | Notes                                                                 |
+|------------|--------|----------|----------|-----------------------------------------------------------------------|
+| `source`   | URI    | yes      | —        | See [§4 Source URIs](#4-source-uris).                                 |
+| `address`  | int    | yes      | —        | Absolute start address on the target bus. Hex literals allowed.       |
+| `bus`      | string | no       | `"main"` | Which bus to load into.                                               |
+
+**Span example.** If the config declares RAM at `0x0000..0x0FFF` and ROM
+at `0x1000..0x10FF` (both on `main`), a binary at `0x0F80` of 0x200
+bytes splits automatically — the first 0x80 bytes land in RAM at offset
+0x0F80, the next 0x80 bytes land in ROM at offset 0. A binary that
+would straddle a gap (e.g. RAM at `0x0000..0x0FFF` and ROM at
+`0x2000..0x20FF`) fails validation with Rule 13.
+
+**ROM payloads.** A binary may target a `read_only: true` region. The
+initial payload is written directly into the underlying `Memory`
+buffer; the read-only guard only affects runtime writes through the
+bus.
+
+---
+
+## 6. The component registry
 
 The registry is a plain dict on the Python side:
 
@@ -374,7 +417,7 @@ not register.
 
 ---
 
-## 6. Presets vs user configs
+## 7. Presets vs user configs
 
 py6502 distinguishes two kinds of configs:
 
@@ -397,7 +440,7 @@ A user can save a preset + their custom edits as a new user config.
 
 ---
 
-## 7. Validation rules
+## 8. Validation rules
 
 The loader runs these checks in order. The **first** failing rule fails
 the load with a clear error message pointing at the offending line.
@@ -418,14 +461,21 @@ the load with a clear error message pointing at the offending line.
 9. **`buses` constraints.** v0.1 only accepts `main`.
 10. **Source URIs resolve.** `resource:` packages must be importable;
     `file:` paths (relative to the config's dir) must exist.
-11. **Source size fits.** For each memory region with a `source`, the
-    source file size must be `<= region.size - load_offset`.
+11. *(reserved)*
 12. **Option targets resolve.** For every entry in `options:`, the
     declared `target:` path must resolve into the raw config (region
     name exists, list index in range, intermediate mappings are dicts
     rather than scalars). Option values must satisfy their declared
     `kind` / `choices` / `min` / `max`. Unknown option ids in a user-
     supplied values dict also fail this rule.
+13. **Binary sources cover a contiguous mapped range.** For every entry
+    in `binaries:`:
+    - the declared `bus` must exist in `buses`;
+    - the source must resolve to at least one byte (Rule 10 handles URI
+      resolution);
+    - the byte range `[address, address + len)` must lie entirely
+      inside the union of memory regions on that bus, with no gaps;
+    - no two binaries on the same bus may overlap.
 
 Validation failures raise `py6502.sim.system.ConfigError` with a message
 of the form:
@@ -438,7 +488,7 @@ ConfigError: apple_i.yaml:12: memory region 'RAM' overlaps with 'ROM' on bus 'ma
 
 ---
 
-## 8. Internal representation
+## 9. Internal representation
 
 After loading and validating, py6502 converts the YAML into a set of
 **frozen dataclasses** defined in `py6502.sim.system.config`:
@@ -463,8 +513,12 @@ class MemoryRegion:
     size: int
     read_only: bool = False
     bus: str = "main"
-    source: Optional[str] = None        # raw URI string
-    load_offset: int = 0
+
+@dataclass(frozen=True)
+class BinarySource:
+    source: str                         # URI, see §4
+    address: int                        # absolute bus address
+    bus: str = "main"
 
 @dataclass(frozen=True)
 class ComponentSpec:
@@ -503,6 +557,7 @@ class SystemConfig:
     inputs: tuple[ComponentSpec, ...] = ()
     audio: Optional[ComponentSpec] = None
     other: tuple[ComponentSpec, ...] = ()
+    binaries: tuple[BinarySource, ...] = ()
     author: Optional[str] = None
     tags: tuple[str, ...] = ()
     options: tuple[OptionSpec, ...] = ()
@@ -520,7 +575,7 @@ same reason.
 
 ---
 
-## 9. How `System` builds from a config
+## 10. How `System` builds from a config
 
 `System.__init__(config: SystemConfig)` does the following, in order:
 
@@ -530,16 +585,21 @@ same reason.
    `BusController` and store it in `self._buses[name]`. Inject the CPU
    into the `main` bus.
 3. **Wire memory regions.** For each `MemoryRegion`: create a `Memory`
-   component of the right size and read-only flag, load bytes from the
-   `source` URI if present (respecting `load_offset`), and call
-   `self._buses[region.bus].add_component(mem, region.start)`.
+   component of the right size and read-only flag and call
+   `self._buses[region.bus].add_component(mem, region.start)`. Regions
+   are zero-initialised.
 4. **Wire peripherals.** Flatten `display` + `inputs` + `audio` +
    `other` into one internal list. For each spec: resolve the type via
    the registry, instantiate with `(bus_controller, **spec.params)`,
    and call `self._buses[spec.bus].add_component(periph, spec.address)`.
    Keep a **direct reference** to the `display` device in
    `self._display` so `get_framebuffer()` never does a lookup.
-5. **Reset.** Call `self._buses["main"].send_reset()`.
+5. **Load binaries.** For each `BinarySource` in `config.binaries`,
+   resolve the URI and walk the covering memory regions on the target
+   bus (validated contiguous by Rule 13), writing each slice into the
+   matching `Memory` component via `set_data` — this path bypasses the
+   runtime read-only guard so `read_only` regions can hold ROM data.
+6. **Reset.** Call `self._buses["main"].send_reset()`.
 
 ### Clocking
 
@@ -562,7 +622,7 @@ a single master cycle count. The external API doesn't change.
 
 ---
 
-## 10. Versioning and forward-compatibility
+## 11. Versioning and forward-compatibility
 
 The `version:` field at the top of every config is the schema version.
 
@@ -586,7 +646,7 @@ The `version:` field at the top of every config is the schema version.
 
 ---
 
-## 11. Future extensions
+## 12. Future extensions
 
 These are documented here so the v0.1 implementation doesn't paint us
 into a corner:
@@ -650,7 +710,10 @@ memory:
     start: 0xFF00
     size: 0x0100        # 256 bytes
     read_only: true
-    source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+
+binaries:
+  - source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+    address: 0xFF00     # wozmon loads into the ROM region
 
 display:
   type: Apple1Display

--- a/src/py6502/sim/assets/presets/apple1.yaml
+++ b/src/py6502/sim/assets/presets/apple1.yaml
@@ -31,7 +31,10 @@ memory:
     start: 0xFF00
     size: 0x0100
     read_only: true
-    source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+
+binaries:
+  - source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+    address: 0xFF00
 
 display:
   type: Apple1Display

--- a/src/py6502/sim/system/__init__.py
+++ b/src/py6502/sim/system/__init__.py
@@ -10,6 +10,7 @@ Public surface:
     - ``OptionSpec`` / ``OptionChoice`` — user-selectable preset options
 """
 from .config import (
+    BinarySource,
     BusSpec,
     ComponentSpec,
     ConfigError,
@@ -24,6 +25,7 @@ from .system import System
 from .writer import to_yaml_text, write_yaml_file
 
 __all__ = [
+    "BinarySource",
     "BusSpec",
     "ComponentSpec",
     "ConfigError",

--- a/src/py6502/sim/system/config.py
+++ b/src/py6502/sim/system/config.py
@@ -35,8 +35,13 @@ class MemoryRegion:
     size: int
     read_only: bool = False
     bus: str = "main"
-    source: Optional[str] = None
-    load_offset: int = 0
+
+
+@dataclass(frozen=True)
+class BinarySource:
+    source: str
+    address: int
+    bus: str = "main"
 
 
 @dataclass(frozen=True)
@@ -104,6 +109,7 @@ class SystemConfig:
     inputs: tuple[ComponentSpec, ...] = ()
     audio: Optional[ComponentSpec] = None
     other: tuple[ComponentSpec, ...] = ()
+    binaries: tuple[BinarySource, ...] = ()
     author: Optional[str] = None
     tags: tuple[str, ...] = ()
     options: tuple[OptionSpec, ...] = ()

--- a/src/py6502/sim/system/loader.py
+++ b/src/py6502/sim/system/loader.py
@@ -16,6 +16,7 @@ from typing import Any
 import yaml
 
 from py6502.sim.system.config import (
+    BinarySource,
     BusSpec,
     ComponentSpec,
     ConfigError,
@@ -31,15 +32,17 @@ from py6502.sim.system.registry import COMPONENT_REGISTRY
 SUPPORTED_SCHEMA_VERSIONS = (1,)
 
 _TOP_LEVEL_REQUIRED = {"version", "id", "name", "description", "cpu", "memory"}
-_TOP_LEVEL_OPTIONAL = {"buses", "display", "inputs", "audio", "other", "author", "tags", "options"}
+_TOP_LEVEL_OPTIONAL = {"buses", "display", "inputs", "audio", "other", "binaries", "author", "tags", "options"}
 _TOP_LEVEL_ALLOWED = _TOP_LEVEL_REQUIRED | _TOP_LEVEL_OPTIONAL
 
 _CPU_REQUIRED = {"type", "hz"}
 _BUS_ALLOWED = {"address_width"}
 _MEMORY_REQUIRED = {"name", "start", "size"}
-_MEMORY_ALLOWED = _MEMORY_REQUIRED | {"read_only", "bus", "source", "load_offset"}
+_MEMORY_ALLOWED = _MEMORY_REQUIRED | {"read_only", "bus"}
 _COMPONENT_REQUIRED = {"type", "address"}
 _COMPONENT_ALLOWED = _COMPONENT_REQUIRED | {"bus", "params"}
+_BINARY_REQUIRED = {"source", "address"}
+_BINARY_ALLOWED = _BINARY_REQUIRED | {"bus"}
 
 _OPTION_REQUIRED = {"id", "label", "kind", "target", "default"}
 _OPTION_ALLOWED = _OPTION_REQUIRED | {"choices", "min", "max", "description"}
@@ -79,7 +82,7 @@ def from_yaml_text(
     Parse ``text`` as YAML, validate it, and return a ``SystemConfig``.
 
     ``base_dir`` is the directory used to resolve ``file:`` URIs on
-    memory regions. ``option_values`` maps option ids to user-selected
+    binary sources. ``option_values`` maps option ids to user-selected
     values; missing entries fall back to each option's declared default.
     """
     try:
@@ -122,6 +125,7 @@ def from_yaml_text(
     inputs = tuple(_parse_component(item, f"inputs[{i}]") for i, item in enumerate(raw.get("inputs") or ()))
     audio = _parse_component(raw.get("audio"), "audio") if raw.get("audio") else None
     other = tuple(_parse_component(item, f"other[{i}]") for i, item in enumerate(raw.get("other") or ()))
+    binaries = _parse_binaries(raw.get("binaries"))
 
     # Rule 4: component types exist
     _require_registered(cpu.type, "cpu.type")
@@ -196,16 +200,8 @@ def from_yaml_text(
                 f"exceeds bus address width ({address_width} bits)"
             )
 
-    # Rules 10 + 11: source URIs resolve and fit the region
-    for region in memory:
-        if region.source is None:
-            continue
-        data = resolve_source(region.source, base_dir)
-        if len(data) + region.load_offset > region.size:
-            raise ConfigError(
-                f"Rule 11: source for region {region.name!r} ({len(data)} bytes at offset "
-                f"0x{region.load_offset:04X}) exceeds region size 0x{region.size:04X}"
-            )
+    # Rule 13: binary sources resolve and cover a contiguous mapped range
+    _validate_binaries(binaries, memory, buses, base_dir)
 
     return SystemConfig(
         version=version,
@@ -219,6 +215,7 @@ def from_yaml_text(
         inputs=inputs,
         audio=audio,
         other=other,
+        binaries=binaries,
         author=raw.get("author"),
         tags=tuple(raw.get("tags") or ()),
         options=options,
@@ -320,11 +317,137 @@ def _parse_memory(raw: Any) -> tuple[MemoryRegion, ...]:
                 size=size,
                 read_only=bool(entry.get("read_only", False)),
                 bus=entry.get("bus", "main"),
-                source=entry.get("source"),
-                load_offset=int(entry.get("load_offset", 0)),
             )
         )
     return tuple(regions)
+
+
+def _parse_binaries(raw: Any) -> tuple[BinarySource, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ConfigError("binaries must be a list")
+    out: list[BinarySource] = []
+    for i, entry in enumerate(raw):
+        label = f"binaries[{i}]"
+        if not isinstance(entry, dict):
+            raise ConfigError(f"{label} must be a mapping")
+        missing = _BINARY_REQUIRED - entry.keys()
+        if missing:
+            raise ConfigError(f"{label} missing required fields: {sorted(missing)}")
+        unknown = entry.keys() - _BINARY_ALLOWED
+        if unknown:
+            raise ConfigError(f"{label} has unknown fields: {sorted(unknown)}")
+        source = entry["source"]
+        address = entry["address"]
+        if not isinstance(source, str) or not source:
+            raise ConfigError(f"{label}.source must be a non-empty string")
+        if not isinstance(address, int):
+            raise ConfigError(f"{label}.address must be an integer")
+        bus = entry.get("bus", "main")
+        if not isinstance(bus, str):
+            raise ConfigError(f"{label}.bus must be a string")
+        out.append(BinarySource(source=source, address=address, bus=bus))
+    return tuple(out)
+
+
+def _validate_binaries(
+    binaries: tuple[BinarySource, ...],
+    memory: tuple[MemoryRegion, ...],
+    buses: dict[str, BusSpec],
+    base_dir: Path,
+) -> None:
+    """
+    Rule 13: each binary source must resolve, be non-empty, and cover a
+    contiguous mapped range on its declared bus. Binaries may not overlap.
+    """
+    placed: list[tuple[int, int, int]] = []  # (address, end_exclusive, index)
+    for i, bs in enumerate(binaries):
+        label = f"binaries[{i}]"
+        if bs.bus not in buses:
+            declared = ", ".join(sorted(buses))
+            raise ConfigError(
+                f"Rule 13: {label} references undeclared bus {bs.bus!r}. Declared: [{declared}]"
+            )
+        data = resolve_source(bs.source, base_dir)  # raises Rule 10 on failure
+        if not data:
+            raise ConfigError(f"Rule 13: {label} source {bs.source!r} is zero bytes")
+
+        same_bus = sorted(
+            (r for r in memory if r.bus == bs.bus), key=lambda r: r.start
+        )
+        if not same_bus:
+            raise ConfigError(
+                f"Rule 13: {label} targets bus {bs.bus!r} which has no memory regions"
+            )
+
+        # Merge adjacent regions into a list of [lo, hi) intervals (half-open).
+        merged: list[list[int]] = []
+        for r in same_bus:
+            lo = r.start
+            hi = r.start + r.size
+            if merged and merged[-1][1] == lo:
+                merged[-1][1] = hi
+            else:
+                merged.append([lo, hi])
+
+        start = bs.address
+        end = start + len(data)
+        # Find the merged interval containing `start`.
+        covering = None
+        for lo, hi in merged:
+            if lo <= start < hi:
+                covering = (lo, hi)
+                break
+        if covering is None:
+            raise ConfigError(
+                f"Rule 13: {label} source {bs.source!r} address 0x{start:04X} "
+                f"is not inside any memory region on bus {bs.bus!r}"
+            )
+        cov_lo, cov_hi = covering
+        if end > cov_hi:
+            # Distinguish "extends past end" from "crosses a gap".
+            tail_inside = any(lo <= end - 1 < hi for lo, hi in merged)
+            if tail_inside and end - 1 >= cov_hi:
+                raise ConfigError(
+                    f"Rule 13: {label} source {bs.source!r} "
+                    f"(0x{len(data):X} bytes at 0x{start:04X}) crosses an unmapped gap "
+                    f"on bus {bs.bus!r}"
+                )
+            raise ConfigError(
+                f"Rule 13: {label} source {bs.source!r} "
+                f"(0x{len(data):X} bytes at 0x{start:04X}) extends past the end of "
+                f"mapped range 0x{cov_lo:04X}..0x{cov_hi - 1:04X} on bus {bs.bus!r}"
+            )
+
+        # Overlap between binaries on the same bus.
+        for other_start, other_end, other_idx in placed:
+            if start < other_end and other_start < end:
+                raise ConfigError(
+                    f"Rule 13: {label} range 0x{start:04X}..0x{end - 1:04X} "
+                    f"overlaps with binaries[{other_idx}] on bus {bs.bus!r}"
+                )
+        placed.append((start, end, i))
+
+
+def regions_covering(
+    memory: tuple[MemoryRegion, ...],
+    bus: str,
+    address: int,
+    length: int,
+) -> tuple[MemoryRegion, ...]:
+    """
+    Return regions on ``bus`` whose range intersects
+    ``[address, address + length)``, sorted by ``start``. Shared by the
+    validator and ``System.__init__`` so both agree on the coverage set.
+    """
+    end = address + length
+    hits = [
+        r for r in memory
+        if r.bus == bus and r.start < end and address < r.start + r.size
+    ]
+    hits.sort(key=lambda r: r.start)
+    return tuple(hits)
 
 
 def _parse_component(raw: Any, label: str) -> ComponentSpec:

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -15,7 +15,7 @@ from py6502.sim.cpu.mos6502 cimport MOS6502, Registers
 
 from py6502.sim.system.config import ComponentSpec, ConfigError, MemoryRegion, SystemConfig
 from py6502.sim.system.loader import from_yaml_file as _loader_from_yaml_file
-from py6502.sim.system.loader import resolve_source
+from py6502.sim.system.loader import regions_covering, resolve_source
 from py6502.sim.system.registry import resolve as _resolve_type
 
 
@@ -45,11 +45,28 @@ cdef class System:
         resolve_base = Path(base_dir) if base_dir is not None else Path.cwd()
         for region in config.memory:
             mem = Memory(region.size, region.name, region.read_only)
-            if region.source is not None:
-                data = resolve_source(region.source, resolve_base)
-                mem.set_data(list(data), region.load_offset)
             self._wire_component(mem, region.start, region.bus)
             self._memory_regions[region.name] = mem
+
+        # --- Binary sources ---------------------------------------------
+        # Rule 13 has already validated coverage; this loop can trust the
+        # config and just walk covering regions, slicing bytes into each.
+        for bs in config.binaries:
+            data = resolve_source(bs.source, resolve_base)
+            cursor = bs.address
+            offset = 0
+            remaining = len(data)
+            for region in regions_covering(config.memory, bs.bus, bs.address, remaining):
+                local = cursor - region.start
+                take = min(region.size - local, remaining)
+                (<Memory>self._memory_regions[region.name]).set_data(
+                    list(data[offset:offset + take]), local
+                )
+                cursor += take
+                offset += take
+                remaining -= take
+                if remaining == 0:
+                    break
 
         # --- Display ----------------------------------------------------
         if config.display is not None:

--- a/src/py6502/sim/system/writer.py
+++ b/src/py6502/sim/system/writer.py
@@ -6,13 +6,11 @@ builder produces: no options, main bus only, everything resolved to
 concrete values. Round-trips through ``from_yaml_text`` to an equal
 ``SystemConfig`` dataclass.
 
-Address-like fields (``start``, ``size``, ``address``, ``load_offset``)
-emit as ``0x…`` hex literals. Everything else uses YAML's default int
-representer.
+Address-like fields (``start``, ``size``, ``address``) emit as ``0x…``
+hex literals. Everything else uses YAML's default int representer.
 """
 from __future__ import annotations
 
-from dataclasses import asdict
 from pathlib import Path
 
 import yaml
@@ -60,6 +58,8 @@ def to_yaml_text(config: SystemConfig) -> str:
         doc["audio"] = _component_dict(config.audio)
     if config.other:
         doc["other"] = [_component_dict(c) for c in config.other]
+    if config.binaries:
+        doc["binaries"] = [_binary_dict(b) for b in config.binaries]
 
     return yaml.dump(doc, Dumper=_SystemConfigDumper, sort_keys=False)
 
@@ -79,10 +79,6 @@ def _region_dict(region) -> dict:
         out["read_only"] = True
     if region.bus != "main":
         out["bus"] = region.bus
-    if region.source is not None:
-        out["source"] = region.source
-    if region.load_offset:
-        out["load_offset"] = _HexInt(region.load_offset)
     return out
 
 
@@ -95,4 +91,14 @@ def _component_dict(spec) -> dict:
         out["bus"] = spec.bus
     if spec.params:
         out["params"] = dict(spec.params)
+    return out
+
+
+def _binary_dict(bs) -> dict:
+    out: dict = {
+        "source": bs.source,
+        "address": _HexInt(bs.address),
+    }
+    if bs.bus != "main":
+        out["bus"] = bs.bus
     return out

--- a/src/py6502/ui/windows/systemselector.py
+++ b/src/py6502/ui/windows/systemselector.py
@@ -8,14 +8,17 @@ from typing import TYPE_CHECKING
 import dearpygui.dearpygui as dpg
 
 from py6502.sim.system import (
+    BinarySource,
     ComponentSpec,
+    ConfigError,
     CpuSpec,
     MemoryRegion,
     OptionSpec,
-    System,
     SystemConfig,
+    to_yaml_text,
     write_yaml_file,
 )
+from py6502.sim.system.loader import from_yaml_text
 from py6502.ui.utils import paths
 from py6502.ui.utils.presets import discover_presets, load_user_config_metadata
 from py6502.ui.utils.settings import save_settings
@@ -75,6 +78,7 @@ CUSTOM_FORM_TAG = "CustomSystemForm"
 CUSTOM_NAME_TAG = "CustomSystemName"
 CUSTOM_CPU_HZ_TAG = "CustomSystemCpuHz"
 CUSTOM_REGIONS_TAG = "CustomSystemRegionsGroup"
+CUSTOM_BINARIES_TAG = "CustomSystemBinariesGroup"
 CUSTOM_DISPLAY_TAG = "CustomSystemDisplay"
 CUSTOM_DISPLAY_ADDR_TAG = "CustomSystemDisplayAddr"
 CUSTOM_INPUT_TAG = "CustomSystemInput"
@@ -91,6 +95,8 @@ class SystemSelectorWindow:
         self._selected_is_custom = False
         self._region_counter = 0
         self._region_ids: list[int] = []
+        self._binary_counter = 0
+        self._binary_ids: list[int] = []
         self._source_dialog_target: int | None = None
         # Per-preset option selections, keyed by preset path. Persists across
         # re-selects so the user's picks stick if they navigate away and back.
@@ -191,6 +197,15 @@ class SystemSelectorWindow:
             dpg.add_group(tag=CUSTOM_REGIONS_TAG)
 
             dpg.add_separator()
+            with dpg.group(horizontal=True):
+                dpg.add_text("Binary Sources", color=(200, 200, 100))
+                dpg.add_button(
+                    label="+ Add Binary",
+                    callback=lambda s, a, u: self._add_binary(),
+                )
+            dpg.add_group(tag=CUSTOM_BINARIES_TAG)
+
+            dpg.add_separator()
             dpg.add_text("Peripherals", color=(200, 200, 100))
             with dpg.group(horizontal=True):
                 dpg.add_text("Display:")
@@ -218,7 +233,7 @@ class SystemSelectorWindow:
                 )
 
             dpg.add_spacer(height=4)
-            dpg.add_text("", tag=CUSTOM_STATUS_TAG)
+            dpg.add_text("", tag=CUSTOM_STATUS_TAG, wrap=600)
 
     # ------------------------------------------------------------------
     # Dynamic memory regions
@@ -257,42 +272,63 @@ class SystemSelectorWindow:
                     callback=lambda s, a, u: self._remove_region(u),
                     user_data=rid,
                 )
-            with dpg.group(horizontal=True):
-                dpg.add_text("  Source:")
-                dpg.add_input_text(
-                    tag=f"RegionSource_{rid}", readonly=True,
-                    width=260, hint="(optional binary)",
-                )
-                dpg.add_button(
-                    label="Browse...",
-                    callback=lambda s, a, u: self._browse_source(u),
-                    user_data=rid,
-                )
-                dpg.add_button(
-                    label="Clear",
-                    callback=lambda s, a, u: dpg.set_value(f"RegionSource_{u}", ""),
-                    user_data=rid,
-                )
 
     def _remove_region(self, rid: int) -> None:
         if rid in self._region_ids:
             self._region_ids.remove(rid)
             dpg.delete_item(f"CustomRegion_{rid}")
 
-    def _browse_source(self, rid: int) -> None:
-        self._source_dialog_target = rid
+    def _add_binary(self, path: str = "", address: str = "0000") -> None:
+        bid = self._binary_counter
+        self._binary_counter += 1
+        self._binary_ids.append(bid)
+
+        with dpg.group(tag=f"CustomBinary_{bid}", parent=CUSTOM_BINARIES_TAG):
+            with dpg.group(horizontal=True):
+                dpg.add_input_text(
+                    tag=f"BinarySource_{bid}", readonly=True,
+                    default_value=path,
+                    width=260, hint="Binary file",
+                )
+                dpg.add_button(
+                    label="Browse...",
+                    callback=lambda s, a, u: self._browse_source(u),
+                    user_data=bid,
+                )
+                dpg.add_text(" @ 0x")
+                dpg.add_input_text(
+                    tag=f"BinaryAddr_{bid}", default_value=address,
+                    width=60, uppercase=True, hexadecimal=True, no_spaces=True,
+                )
+                dpg.add_button(
+                    label="X", width=24,
+                    callback=lambda s, a, u: self._remove_binary(u),
+                    user_data=bid,
+                )
+
+    def _remove_binary(self, bid: int) -> None:
+        if bid in self._binary_ids:
+            self._binary_ids.remove(bid)
+            dpg.delete_item(f"CustomBinary_{bid}")
+
+    def _browse_source(self, bid: int) -> None:
+        self._source_dialog_target = bid
         dpg.show_item(SOURCE_FILE_DIALOG_TAG)
 
     def _on_source_file_selected(self, sender: int, app_data: dict, user_data: object) -> None:
         file_path = app_data.get("file_path_name", "")
         if file_path and self._source_dialog_target is not None:
-            dpg.set_value(f"RegionSource_{self._source_dialog_target}", file_path)
+            dpg.set_value(f"BinarySource_{self._source_dialog_target}", file_path)
 
     def _reset_custom_form(self) -> None:
         for rid in list(self._region_ids):
             self._remove_region(rid)
         self._region_ids.clear()
         self._region_counter = 0
+        for bid in list(self._binary_ids):
+            self._remove_binary(bid)
+        self._binary_ids.clear()
+        self._binary_counter = 0
         self._add_region(name="RAM", start="0000", size="1000")
 
     # ------------------------------------------------------------------
@@ -388,12 +424,23 @@ class SystemSelectorWindow:
         for region in config.memory:
             end = region.start + region.size - 1
             tag = " [ROM]" if region.read_only else ""
-            src = f"  ← {Path(region.source).name}" if region.source else ""
             dpg.add_text(
                 f"  {region.name}  0x{region.start:04X}-0x{end:04X}  "
-                f"({_format_bytes(region.size)}){tag}{src}",
+                f"({_format_bytes(region.size)}){tag}",
                 parent=INFO_PANE_TAG, color=(180, 180, 180),
             )
+        if config.binaries:
+            dpg.add_text("Binaries:", parent=INFO_PANE_TAG, color=(180, 180, 180))
+            for bs in config.binaries:
+                label = bs.source
+                if bs.source.startswith("file:"):
+                    label = Path(bs.source[len("file:"):]).name
+                elif bs.source.startswith("resource:"):
+                    label = bs.source[len("resource:"):].rsplit("/", 1)[-1]
+                dpg.add_text(
+                    f"  {label} @ 0x{bs.address:04X}",
+                    parent=INFO_PANE_TAG, color=(180, 180, 180),
+                )
         if config.display is not None:
             dpg.add_text(
                 f"Display: {config.display.type} @ 0x{config.display.address:04X}",
@@ -537,6 +584,10 @@ class SystemSelectorWindow:
             self._set_status("Add at least one memory region", error=True)
             return
 
+        binaries = self._collect_binaries()
+        if binaries is None:
+            return
+
         display = self._collect_display()
         if display is False:
             return
@@ -553,16 +604,19 @@ class SystemSelectorWindow:
             memory=tuple(memory),
             display=display if display else None,
             inputs=tuple(inputs) if inputs else (),
+            binaries=binaries,
         )
 
-        # Validate by constructing once before writing to disk.
+        # Validate via the loader before writing to disk — exercises
+        # Rule 13 binary coverage, which System.__init__ does not re-run.
+        target_dir = paths.user_configs_dir()
         try:
-            System(config)
-        except Exception as exc:
+            from_yaml_text(to_yaml_text(config), base_dir=target_dir)
+        except ConfigError as exc:
             self._set_status(str(exc), error=True)
             return
 
-        target = _unique_config_path(paths.user_configs_dir(), slug)
+        target = _unique_config_path(target_dir, slug)
         try:
             write_yaml_file(config, target)
         except OSError as exc:
@@ -594,13 +648,25 @@ class SystemSelectorWindow:
                 self._set_status(f"Region '{r_name}' has zero size", error=True)
                 return None
             r_ro = dpg.get_value(f"RegionRO_{rid}")
-            r_source = dpg.get_value(f"RegionSource_{rid}").strip()
-            source = f"file:{r_source}" if r_source else None
             regions.append(MemoryRegion(
-                name=r_name, start=r_start, size=r_size,
-                read_only=r_ro, source=source,
+                name=r_name, start=r_start, size=r_size, read_only=r_ro,
             ))
         return regions
+
+    def _collect_binaries(self) -> tuple[BinarySource, ...] | None:
+        out: list[BinarySource] = []
+        for bid in self._binary_ids:
+            path = dpg.get_value(f"BinarySource_{bid}").strip()
+            if not path:
+                self._set_status("A binary source has no file selected", error=True)
+                return None
+            try:
+                addr = int(dpg.get_value(f"BinaryAddr_{bid}"), 16)
+            except ValueError:
+                self._set_status(f"Invalid hex address for binary '{path}'", error=True)
+                return None
+            out.append(BinarySource(source=f"file:{path}", address=addr))
+        return tuple(out)
 
     def _collect_display(self) -> ComponentSpec | None | bool:
         display_type = dpg.get_value(CUSTOM_DISPLAY_TAG)

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -1,0 +1,200 @@
+"""
+Tests for the top-level `binaries:` config section (issue #42).
+
+Binaries are loaded during ``System.__init__`` before reset, so the bytes
+are observable via ``System.peek``. Coverage validation lives in the
+loader (Rule 13); construction trusts the config.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from py6502.sim.system import (
+    BinarySource,
+    ConfigError,
+    CpuSpec,
+    MemoryRegion,
+    System,
+    SystemConfig,
+)
+from py6502.sim.system.loader import from_yaml_text
+
+
+def _base_yaml(
+    *,
+    memory: str,
+    binaries: str,
+) -> str:
+    return f"""
+version: 1
+id: bintest
+name: BinTest
+description: binaries test fixture
+cpu:
+  type: MOS6502
+  hz: 1000000
+memory:
+{memory}
+binaries:
+{binaries}
+"""
+
+
+def _write_bin(tmp_path: Path, name: str, size: int, fill: int = 0xAB) -> Path:
+    target = tmp_path / name
+    target.write_bytes(bytes([fill]) * size)
+    return target
+
+
+def test_binary_loads_into_single_region(tmp_path: Path) -> None:
+    path = _write_bin(tmp_path, "prog.bin", 0x10, fill=0x5A)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=f"  - {{ source: 'file:{path}', address: 0x0100 }}",
+    )
+    config = from_yaml_text(text, base_dir=tmp_path)
+    system = System(config, base_dir=tmp_path)
+    assert system.peek(0x0100) == 0x5A
+    assert system.peek(0x010F) == 0x5A
+    # Neighbours untouched.
+    assert system.peek(0x00FF) == 0x00
+    assert system.peek(0x0110) == 0x00
+
+
+def test_binary_spans_two_contiguous_regions(tmp_path: Path) -> None:
+    # RAM 0x0000-0x0FFF and ROM 0x1000-0x10FF are adjacent; a 0x100-byte
+    # binary at 0x0F80 crosses the boundary: the first 0x80 bytes land
+    # in RAM, the next 0x80 in ROM.
+    data = bytes(i & 0xFF for i in range(0x100))
+    target = tmp_path / "span.bin"
+    target.write_bytes(data)
+    text = _base_yaml(
+        memory=(
+            "  - { name: RAM, start: 0x0000, size: 0x1000 }\n"
+            "  - { name: ROM, start: 0x1000, size: 0x0100, read_only: true }"
+        ),
+        binaries=f"  - {{ source: 'file:{target}', address: 0x0F80 }}",
+    )
+    config = from_yaml_text(text, base_dir=tmp_path)
+    system = System(config, base_dir=tmp_path)
+    # First byte of the binary lands at 0x0F80 in RAM.
+    assert system.peek(0x0F80) == data[0]
+    # The byte straddling the boundary is exactly at 0x1000 (ROM start).
+    assert system.peek(0x1000) == data[0x1000 - 0x0F80]
+    # Final byte lands near the end of ROM.
+    assert system.peek(0x0F80 + 0x100 - 1) == data[-1]
+
+
+def test_binary_outside_all_regions_rejected(tmp_path: Path) -> None:
+    path = _write_bin(tmp_path, "p.bin", 0x10)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=f"  - {{ source: 'file:{path}', address: 0x8000 }}",
+    )
+    with pytest.raises(ConfigError, match="Rule 13.*not inside any memory region"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_binary_extends_past_mapped_range_rejected(tmp_path: Path) -> None:
+    # RAM covers 0x0000..0x0FFF. Binary at 0x0F80 of 0x100 bytes reaches
+    # 0x1080, past the last mapped byte — no ROM region follows.
+    path = _write_bin(tmp_path, "p.bin", 0x100)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=f"  - {{ source: 'file:{path}', address: 0x0F80 }}",
+    )
+    with pytest.raises(ConfigError, match="Rule 13.*extends past"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_binary_straddling_a_gap_rejected(tmp_path: Path) -> None:
+    # Regions at 0x0000-0x0FFF and 0x2000-0x20FF leave a gap;
+    # a 0x200-byte binary at 0x0F80 lands inside RAM but its tail lands
+    # in the gap.
+    path = _write_bin(tmp_path, "p.bin", 0x200)
+    text = _base_yaml(
+        memory=(
+            "  - { name: LO, start: 0x0000, size: 0x1000 }\n"
+            "  - { name: HI, start: 0x2000, size: 0x0100 }"
+        ),
+        binaries=f"  - {{ source: 'file:{path}', address: 0x0F80 }}",
+    )
+    with pytest.raises(ConfigError, match="Rule 13.*extends past"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_binary_undeclared_bus_rejected(tmp_path: Path) -> None:
+    # v0.1 Rule 9 fires first on any non-'main' bus name; we assert that
+    # the combination still surfaces a useful error. The test documents
+    # the layering even though Rule 9 preempts Rule 13 here.
+    path = _write_bin(tmp_path, "p.bin", 0x10)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=f"  - {{ source: 'file:{path}', address: 0x0000, bus: graphics }}",
+    )
+    with pytest.raises(ConfigError, match="Rule (9|13)"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_binary_zero_bytes_rejected(tmp_path: Path) -> None:
+    path = _write_bin(tmp_path, "empty.bin", 0)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=f"  - {{ source: 'file:{path}', address: 0x0000 }}",
+    )
+    with pytest.raises(ConfigError, match="Rule 13.*zero bytes"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_overlapping_binaries_rejected(tmp_path: Path) -> None:
+    a = _write_bin(tmp_path, "a.bin", 0x20)
+    b = _write_bin(tmp_path, "b.bin", 0x20)
+    text = _base_yaml(
+        memory="  - { name: RAM, start: 0x0000, size: 0x1000 }",
+        binaries=(
+            f"  - {{ source: 'file:{a}', address: 0x0100 }}\n"
+            f"  - {{ source: 'file:{b}', address: 0x0110 }}"
+        ),
+    )
+    with pytest.raises(ConfigError, match="Rule 13.*overlaps"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_binary_loads_into_read_only_region(tmp_path: Path) -> None:
+    """
+    A binary targeting a ``read_only: true`` region must succeed — the
+    initial payload is written directly into the underlying buffer,
+    bypassing the ROM guard which only applies to runtime writes.
+    """
+    path = _write_bin(tmp_path, "rom.bin", 0x40, fill=0xEE)
+    text = _base_yaml(
+        memory=(
+            "  - { name: RAM, start: 0x0000, size: 0x1000 }\n"
+            "  - { name: ROM, start: 0xFF00, size: 0x0100, read_only: true }"
+        ),
+        binaries=f"  - {{ source: 'file:{path}', address: 0xFF00 }}",
+    )
+    config = from_yaml_text(text, base_dir=tmp_path)
+    system = System(config, base_dir=tmp_path)
+    assert system.peek(0xFF00) == 0xEE
+    assert system.peek(0xFF3F) == 0xEE
+
+
+def test_system_config_direct_construction_load_succeeds(tmp_path: Path) -> None:
+    """
+    Constructing a ``SystemConfig`` directly (bypassing the loader) and
+    handing it to ``System`` should still load the binary — the system
+    trusts an already-validated config.
+    """
+    path = _write_bin(tmp_path, "p.bin", 0x08, fill=0x77)
+    config = SystemConfig(
+        version=1, id="direct", name="Direct", description="",
+        cpu=CpuSpec(type="MOS6502", hz=1_000_000),
+        memory=(MemoryRegion(name="RAM", start=0x0000, size=0x0100),),
+        binaries=(BinarySource(source=f"file:{path}", address=0x0010),),
+    )
+    system = System(config, base_dir=tmp_path)
+    assert system.peek(0x0010) == 0x77
+    assert system.peek(0x0017) == 0x77

--- a/tests/test_system_loader.py
+++ b/tests/test_system_loader.py
@@ -28,7 +28,9 @@ def test_apple1_preset_round_trip() -> None:
     assert region_by_name["RAM"].size == 0x1000
     assert region_by_name["RAM"].read_only is False
     assert region_by_name["ROM"].read_only is True
-    assert region_by_name["ROM"].source is not None
+    assert len(config.binaries) == 1
+    assert config.binaries[0].address == 0xFF00
+    assert config.binaries[0].source.startswith("resource:")
     assert config.display is not None
     assert config.display.type == "Apple1Display"
     assert config.display.address == 0xD012
@@ -171,6 +173,30 @@ memory:
     size: 0x0200
 """
     with pytest.raises(ConfigError, match="Rule 8"):
+        from_yaml_text(text, base_dir=tmp_path)
+
+
+def test_per_region_source_rejected_post_42(tmp_path: Path) -> None:
+    """
+    #42 moved binary sources to a top-level `binaries:` section. The old
+    per-region `source` / `load_offset` fields must now fail Rule 3 as
+    unknown fields — a clean break, no silent migration.
+    """
+    text = """
+version: 1
+id: legacy_source
+name: Legacy
+description: legacy
+cpu:
+  type: MOS6502
+  hz: 1000000
+memory:
+  - name: ROM
+    start: 0xFF00
+    size: 0x0100
+    source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+"""
+    with pytest.raises(ConfigError, match="memory\\[0\\] has unknown fields"):
         from_yaml_text(text, base_dir=tmp_path)
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 from py6502.sim.system import (
+    BinarySource,
     ComponentSpec,
     CpuSpec,
     MemoryRegion,
@@ -37,13 +38,16 @@ def _full() -> SystemConfig:
         cpu=CpuSpec(type="MOS6502", hz=2_000_000),
         memory=(
             MemoryRegion(name="RAM", start=0x0000, size=0x2000, read_only=False),
-            MemoryRegion(
-                name="ROM", start=0xFF00, size=0x0100, read_only=True,
-                source="resource:py6502.sim.assets.bios/apple1-wozmon.bin",
-            ),
+            MemoryRegion(name="ROM", start=0xFF00, size=0x0100, read_only=True),
         ),
         display=ComponentSpec(type="Apple1Display", address=0xD012, params={"blink": True}),
         inputs=(ComponentSpec(type="Apple1Keyboard", address=0xD010),),
+        binaries=(
+            BinarySource(
+                source="resource:py6502.sim.assets.bios/apple1-wozmon.bin",
+                address=0xFF00,
+            ),
+        ),
         author="writer tests",
         tags=("test", "synthetic"),
     )
@@ -94,3 +98,19 @@ def test_write_yaml_file_round_trip(tmp_path):
     assert target.exists()
     restored = from_yaml_text(target.read_text(encoding="utf-8"), base_dir=tmp_path)
     assert restored == original
+
+
+def test_regions_do_not_emit_legacy_source_fields():
+    text = to_yaml_text(_full())
+    assert "source:" in text  # still appears under the binaries section
+    # …but never on a memory region (which precedes the binaries block).
+    region_block, _, binary_block = text.partition("binaries:")
+    assert "source" not in region_block
+    assert "load_offset" not in region_block
+
+
+def test_binaries_section_emits_with_hex_address():
+    text = to_yaml_text(_full())
+    assert "binaries:" in text
+    assert "address: 0xFF00" in text
+    assert "resource:py6502.sim.assets.bios/apple1-wozmon.bin" in text


### PR DESCRIPTION
## Summary
- Add top-level `binaries:` config section (`BinarySource{source, address, bus}`) and drop `source` / `load_offset` from `MemoryRegion`.
- Support binaries that span multiple contiguous memory regions; the loader slices data across the matching `Memory` components.
- New validation Rule 13: bus declared, source resolves, non-empty, coverage contiguous, no gaps, no binary-vs-binary overlap.
- Custom system builder: remove per-region source widgets, add a "Binary Sources" panel with add/remove rows, browse picker, and hex address input; inline validation round-trips through the loader before writing YAML.
- Migrate the Apple I preset to the new shape; rewrite `docs/SYSTEM_CONFIG.md` (§5 Binaries, renumbered rules, updated dataclass reference).
- Roadmap pull: drop closed #49 from the v0.1 open-issue list.

## Why
Per-region `source` tied a binary to exactly one `MemoryRegion`, with a `load_offset` knob for the in-region placement. That couldn't represent a payload spanning adjacent regions, forced the UI to expose binary pickers per-region (which doesn't match how users think about loading a ROM), and gave issue #51 (bundled-asset picker) nowhere clean to hook. Pulling binaries up to a first-class top-level concept with absolute addresses reflects the hardware view — "this ROM goes at `\$FF00`" — and sets the shape for #51 to plug into. Clean break on the YAML format is the right call pre-v0.1; no compat shim.

## Test plan
- [x] `pytest` — 62/62 pass, including 10 new cases in `tests/test_binaries.py` covering single-region, cross-region span, outside-regions, extends-past, gap, undeclared-bus, zero-byte, overlapping binaries, ROM load, and direct `SystemConfig` construction.
- [x] Apple I preset boots: wozmon loaded at `\$FF00`, reset vector points at `\$FF00`, framebuffer renders after 100k cycles.
- [x] UI smoke: custom system builder adds/removes binary rows, Rule 13 errors surface inline (and wrap cleanly inside the right pane after the `wrap=600` tweak on `CUSTOM_STATUS_TAG`).
- [x] Migration rejection: a YAML with legacy `memory[].source` fails Rule 3 as expected.

## Closes
Closes #42