### PR TITLE
Migrate runtime Load Binary window to address-based model

### DIFF
--- a/.claude/agents/sim-perf-reviewer.md
+++ b/.claude/agents/sim-perf-reviewer.md
@@ -79,7 +79,7 @@ For each candidate file:
   docstrings).
 - Don't flag changes outside `src/py6502/sim/`.
 - Don't flag one-shot configuration loops (`__cinit__`, `reset`,
-  `load_binary`, `add_component`) — those are allowed to be as Pythonic
+  `load_binary_at`, `add_component`) — those are allowed to be as Pythonic
   as they want.
 - Don't propose architectural rewrites that go beyond the rules above.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -294,6 +294,7 @@ cdef class System:
     cdef Component _display               # direct ref, avoids string lookups
     cdef list _inputs                     # keyboard-likes, in declared order
     cdef dict _memory_regions             # str → Memory
+    cdef tuple _memory_config             # MemoryRegion tuple, kept for runtime binary loads
 ```
 
 Construction is described in detail in [SYSTEM_CONFIG.md §9](SYSTEM_CONFIG.md#9-how-system-builds-from-a-config).
@@ -308,7 +309,7 @@ cpdef void run_for_microseconds(self, unsigned long microseconds)
 cpdef unsigned long step_cycle(self)       # debug: advance one CPU clock cycle
 cpdef unsigned long step_instruction(self) # debug: advance one full instruction
 cpdef void reset(self)
-cpdef void load_binary(self, str region_name, unsigned int offset, bytes data)
+cpdef void load_binary_at(self, unsigned int address, bytes data)
 cpdef Registers get_registers(self)
 cpdef void set_registers(self, Registers registers)
 cpdef object get_framebuffer(self)
@@ -320,10 +321,6 @@ cpdef void set_invalid_opcode_mode(self, unsigned char mode)
 cpdef void set_unmapped_memory_mode(self, bint crash)
 cpdef bint send_key(self, unsigned char char_)
 cpdef void clear_input_buffer(self)
-```
-
-```python
-system.memory_region_names   # property: tuple of configured region names
 ```
 
 `step_cycle` and `step_instruction` are debug-only entry points — not

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,8 +63,8 @@ wrong here, every later release pays for it.
 
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
-- [#42](https://github.com/ricky-groenewald/py6502/issues/42) — Address-based binary loading in custom system builder
 - [#51](https://github.com/ricky-groenewald/py6502/issues/51) — Binary source picker: filesystem vs bundled assets, backed by an asset manifest
+- [#57](https://github.com/ricky-groenewald/py6502/issues/57) — Migrate runtime Load Binary window to address-based model
 
 **Explicit non-goals for v0.1.**
 

--- a/docs/SYSTEM_CONFIG.md
+++ b/docs/SYSTEM_CONFIG.md
@@ -169,7 +169,7 @@ memory:
 
 | Field         | Type   | Required | Default  | Notes                                                                 |
 |---------------|--------|----------|----------|-----------------------------------------------------------------------|
-| `name`        | string | yes      | —        | Must be unique within this config. Referenced by `load_binary`.       |
+| `name`        | string | yes      | —        | Must be unique within this config. Preserved for diagnostics and YAML round-trip. |
 | `start`       | int    | yes      | —        | Bus address where the region begins. Hex literals (`0x0000`) allowed. |
 | `size`        | int    | yes      | —        | Number of bytes. Must satisfy `start + size <= 2**address_width`.     |
 | `read_only`   | bool   | no       | `false`  | If `true`, runtime writes are silently dropped (ROM semantics).       |

--- a/src/py6502/sim/README.md
+++ b/src/py6502/sim/README.md
@@ -46,7 +46,7 @@ from py6502.sim.peripherals import Apple1
    state.
 4. A `System` builds all of the above from a `SystemConfig` (see
    `docs/SYSTEM_CONFIG.md`) and exposes a coarse, frontend-facing API:
-   `run_cycles`, `run_for_microseconds`, `reset`, `load_binary`,
+   `run_cycles`, `run_for_microseconds`, `reset`, `load_binary_at`,
    `get_registers`, `get_framebuffer`. The frontend calls one of these
    once per UI frame.
 

--- a/src/py6502/sim/system/loader.py
+++ b/src/py6502/sim/system/loader.py
@@ -351,6 +351,75 @@ def _parse_binaries(raw: Any) -> tuple[BinarySource, ...]:
     return tuple(out)
 
 
+def validate_coverage(
+    memory: tuple[MemoryRegion, ...],
+    bus: str,
+    address: int,
+    length: int,
+    *,
+    label: str,
+) -> tuple[MemoryRegion, ...]:
+    """
+    Check that ``[address, address + length)`` is covered by a contiguous
+    run of memory regions on ``bus``. Raises ``ConfigError`` prefixed with
+    ``label`` on failure; returns the covering regions (sorted by start)
+    on success. Shared by ``_validate_binaries`` at config time and
+    ``System.load_binary_at`` at runtime so the two paths agree on
+    wording and rules.
+    """
+    if length == 0:
+        raise ConfigError(f"{label} is zero bytes")
+
+    same_bus = sorted(
+        (r for r in memory if r.bus == bus), key=lambda r: r.start
+    )
+    if not same_bus:
+        raise ConfigError(
+            f"{label} targets bus {bus!r} which has no memory regions"
+        )
+
+    # Merge adjacent regions into a list of [lo, hi) intervals (half-open).
+    merged: list[list[int]] = []
+    for r in same_bus:
+        lo = r.start
+        hi = r.start + r.size
+        if merged and merged[-1][1] == lo:
+            merged[-1][1] = hi
+        else:
+            merged.append([lo, hi])
+
+    start = address
+    end = start + length
+    # Find the merged interval containing `start`.
+    covering = None
+    for lo, hi in merged:
+        if lo <= start < hi:
+            covering = (lo, hi)
+            break
+    if covering is None:
+        raise ConfigError(
+            f"{label} address 0x{start:04X} "
+            f"is not inside any memory region on bus {bus!r}"
+        )
+    cov_lo, cov_hi = covering
+    if end > cov_hi:
+        # Distinguish "extends past end" from "crosses a gap".
+        tail_inside = any(lo <= end - 1 < hi for lo, hi in merged)
+        if tail_inside and end - 1 >= cov_hi:
+            raise ConfigError(
+                f"{label} "
+                f"(0x{length:X} bytes at 0x{start:04X}) crosses an unmapped gap "
+                f"on bus {bus!r}"
+            )
+        raise ConfigError(
+            f"{label} "
+            f"(0x{length:X} bytes at 0x{start:04X}) extends past the end of "
+            f"mapped range 0x{cov_lo:04X}..0x{cov_hi - 1:04X} on bus {bus!r}"
+        )
+
+    return regions_covering(memory, bus, address, length)
+
+
 def _validate_binaries(
     binaries: tuple[BinarySource, ...],
     memory: tuple[MemoryRegion, ...],
@@ -370,56 +439,16 @@ def _validate_binaries(
                 f"Rule 13: {label} references undeclared bus {bs.bus!r}. Declared: [{declared}]"
             )
         data = resolve_source(bs.source, base_dir)  # raises Rule 10 on failure
-        if not data:
-            raise ConfigError(f"Rule 13: {label} source {bs.source!r} is zero bytes")
-
-        same_bus = sorted(
-            (r for r in memory if r.bus == bs.bus), key=lambda r: r.start
+        validate_coverage(
+            memory,
+            bs.bus,
+            bs.address,
+            len(data),
+            label=f"Rule 13: {label} source {bs.source!r}",
         )
-        if not same_bus:
-            raise ConfigError(
-                f"Rule 13: {label} targets bus {bs.bus!r} which has no memory regions"
-            )
-
-        # Merge adjacent regions into a list of [lo, hi) intervals (half-open).
-        merged: list[list[int]] = []
-        for r in same_bus:
-            lo = r.start
-            hi = r.start + r.size
-            if merged and merged[-1][1] == lo:
-                merged[-1][1] = hi
-            else:
-                merged.append([lo, hi])
 
         start = bs.address
         end = start + len(data)
-        # Find the merged interval containing `start`.
-        covering = None
-        for lo, hi in merged:
-            if lo <= start < hi:
-                covering = (lo, hi)
-                break
-        if covering is None:
-            raise ConfigError(
-                f"Rule 13: {label} source {bs.source!r} address 0x{start:04X} "
-                f"is not inside any memory region on bus {bs.bus!r}"
-            )
-        cov_lo, cov_hi = covering
-        if end > cov_hi:
-            # Distinguish "extends past end" from "crosses a gap".
-            tail_inside = any(lo <= end - 1 < hi for lo, hi in merged)
-            if tail_inside and end - 1 >= cov_hi:
-                raise ConfigError(
-                    f"Rule 13: {label} source {bs.source!r} "
-                    f"(0x{len(data):X} bytes at 0x{start:04X}) crosses an unmapped gap "
-                    f"on bus {bs.bus!r}"
-                )
-            raise ConfigError(
-                f"Rule 13: {label} source {bs.source!r} "
-                f"(0x{len(data):X} bytes at 0x{start:04X}) extends past the end of "
-                f"mapped range 0x{cov_lo:04X}..0x{cov_hi - 1:04X} on bus {bs.bus!r}"
-            )
-
         # Overlap between binaries on the same bus.
         for other_start, other_end, other_idx in placed:
             if start < other_end and other_start < end:

--- a/src/py6502/sim/system/system.pxd
+++ b/src/py6502/sim/system/system.pxd
@@ -12,13 +12,14 @@ cdef class System:
     cdef Component _display
     cdef list _inputs
     cdef dict _memory_regions
+    cdef tuple _memory_config
 
     cpdef void run_cycles(self, unsigned long cycles) except *
     cpdef void run_for_microseconds(self, unsigned long microseconds) except *
     cpdef unsigned long step_cycle(self) except *
     cpdef unsigned long step_instruction(self) except *
     cpdef void reset(self)
-    cpdef void load_binary(self, str region_name, unsigned int offset, bytes data)
+    cpdef void load_binary_at(self, unsigned int address, bytes data)
     cpdef Registers get_registers(self)
     cpdef void set_registers(self, Registers registers)
     cpdef object get_framebuffer(self)

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -15,7 +15,7 @@ from py6502.sim.cpu.mos6502 cimport MOS6502, Registers
 
 from py6502.sim.system.config import ComponentSpec, ConfigError, MemoryRegion, SystemConfig
 from py6502.sim.system.loader import from_yaml_file as _loader_from_yaml_file
-from py6502.sim.system.loader import regions_covering, resolve_source
+from py6502.sim.system.loader import regions_covering, resolve_source, validate_coverage
 from py6502.sim.system.registry import resolve as _resolve_type
 
 
@@ -31,6 +31,7 @@ cdef class System:
         self._cpu_hz = config.cpu.hz
         self._buses = {}
         self._memory_regions = {}
+        self._memory_config = config.memory
         self._inputs = []
         self._display = None
 
@@ -111,10 +112,6 @@ cdef class System:
     def cpu_hz(self):
         return self._cpu_hz
 
-    @property
-    def memory_region_names(self):
-        return tuple(self._memory_regions.keys())
-
     cpdef void run_cycles(self, unsigned long cycles) except *:
         if cycles:
             (<BusController>self._buses["main"]).run_cycles(cycles)
@@ -147,10 +144,40 @@ cdef class System:
     cpdef void reset(self):
         (<BusController>self._buses["main"]).send_reset()
 
-    cpdef void load_binary(self, str region_name, unsigned int offset, bytes data):
-        if region_name not in self._memory_regions:
-            raise KeyError(f"Unknown memory region: {region_name}")
-        (<Memory>self._memory_regions[region_name]).set_data(list(data), offset)
+    cpdef void load_binary_at(self, unsigned int address, bytes data):
+        # Runtime counterpart to config-time binary loading. validate_coverage
+        # runs the same Rule-13-shape checks (zero bytes, address inside a
+        # region, contiguous, doesn't run off the end) and returns the
+        # covering regions; the write loop mirrors __init__'s behaviour.
+        # Like config-time loads, this writes through Memory.set_data, which
+        # bypasses the read_only flag — loading a ROM image at runtime is
+        # intentional, not a bug.
+        cdef unsigned int cursor, local, take, offset, remaining
+        if address > 0xFFFF:
+            raise ConfigError(
+                f"load_binary_at: address 0x{address:X} is outside the 16-bit bus"
+            )
+        covering = validate_coverage(
+            self._memory_config,
+            "main",
+            address,
+            len(data),
+            label="load_binary_at:",
+        )
+        cursor = address
+        offset = 0
+        remaining = len(data)
+        for region in covering:
+            local = cursor - region.start
+            take = min(region.size - local, remaining)
+            (<Memory>self._memory_regions[region.name]).set_data(
+                list(data[offset:offset + take]), local
+            )
+            cursor += take
+            offset += take
+            remaining -= take
+            if remaining == 0:
+                break
 
     cpdef Registers get_registers(self):
         return (<BusController>self._buses["main"]).get_registers()

--- a/src/py6502/ui/CLAUDE.md
+++ b/src/py6502/ui/CLAUDE.md
@@ -16,7 +16,7 @@ windows/                  DearPyGui modals and panels
 ├── video.py              Video output window + texture management
 ├── debug.py              Debug panel (controls, registers, memory monitor)
 ├── systemselector.py     System selection modal (presets + user YAMLs)
-├── binaryloader.py       Binary load dialog (region + offset)
+├── binaryloader.py       Binary load dialog (absolute address)
 ├── settings.py           Settings window
 └── about.py              Custom About dialog
 utils/                    Small helpers

--- a/src/py6502/ui/windows/binaryloader.py
+++ b/src/py6502/ui/windows/binaryloader.py
@@ -1,4 +1,4 @@
-"""Binary loader dialog — load a .bin/.rom file into a named memory region."""
+"""Binary loader dialog — load a .bin/.rom file at an absolute address."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
 
 WINDOW_TAG = "BinaryLoaderWindow"
 FILE_PATH_TAG = "BinaryLoaderFilePath"
-REGION_DROPDOWN_TAG = "BinaryLoaderRegionDropdown"
-OFFSET_TAG = "BinaryLoaderOffset"
+ADDRESS_TAG = "BinaryLoaderAddress"
 STATUS_TAG = "BinaryLoaderStatus"
 FILE_DIALOG_TAG = "BinaryLoaderFileDialog"
 
@@ -40,19 +39,13 @@ class BinaryLoaderWindow:
                 )
                 dpg.add_button(label="Browse...", callback=self._on_browse)
 
-            # Region + offset row
+            # Address row
             with dpg.group(horizontal=True):
-                dpg.add_text("Region:")
-                dpg.add_combo(
-                    tag=REGION_DROPDOWN_TAG,
-                    items=[],
-                    width=120,
-                )
-                dpg.add_text("  Offset: 0x")
+                dpg.add_text("Address: 0x")
                 dpg.add_input_text(
-                    tag=OFFSET_TAG,
+                    tag=ADDRESS_TAG,
                     default_value="0000",
-                    width=50,
+                    width=60,
                     uppercase=True,
                     hexadecimal=True,
                     no_spaces=True,
@@ -80,20 +73,11 @@ class BinaryLoaderWindow:
             dpg.add_file_extension(".*")
 
     def show(self) -> None:
-        # Reset state
         self._file_path = ""
         dpg.set_value(FILE_PATH_TAG, "")
-        dpg.set_value(OFFSET_TAG, "0000")
+        dpg.set_value(ADDRESS_TAG, "0000")
         dpg.set_value(STATUS_TAG, "")
         dpg.configure_item(STATUS_TAG, color=(255, 255, 255))
-
-        # Populate region dropdown from current system
-        if self._app.system is not None:
-            regions = list(self._app.system.memory_region_names)
-            dpg.configure_item(REGION_DROPDOWN_TAG, items=regions)
-            if regions:
-                dpg.set_value(REGION_DROPDOWN_TAG, regions[0])
-
         dpg.show_item(WINDOW_TAG)
 
     # ------------------------------------------------------------------
@@ -116,26 +100,21 @@ class BinaryLoaderWindow:
             self._set_status("No file selected", error=True)
             return
 
-        region = dpg.get_value(REGION_DROPDOWN_TAG)
-        if not region:
-            self._set_status("No memory region selected", error=True)
-            return
-
-        offset_str = dpg.get_value(OFFSET_TAG)
+        address_str = dpg.get_value(ADDRESS_TAG)
         try:
-            offset = int(offset_str, 16)
+            address = int(address_str, 16)
         except ValueError:
-            self._set_status("Invalid offset value", error=True)
+            self._set_status("Invalid address value", error=True)
             return
 
         try:
             data = Path(self._file_path).read_bytes()
-            self._app.system.load_binary(region, offset, data)
-        except (IOError, KeyError, Exception) as exc:
+            self._app.system.load_binary_at(address, data)
+        except Exception as exc:
             self._set_status(str(exc), error=True)
             return
 
-        self._set_status(f"Loaded {len(data)} bytes into {region} at offset 0x{offset:04X}")
+        self._set_status(f"Loaded {len(data)} bytes at 0x{address:04X}")
         dpg.hide_item(WINDOW_TAG)
 
     def _on_cancel(self) -> None:

--- a/tests/test_invalid_opcode.py
+++ b/tests/test_invalid_opcode.py
@@ -53,7 +53,7 @@ def system(tmp_path):
 def test_crash_mode_raises_on_invalid_opcode(system) -> None:
     """Default crash mode raises InvalidOPCode during run_cycles."""
     # 0x02 is an undefined 6502 opcode at 0x0200
-    system.load_binary("RAM", 0x0200, bytes([0x02]))
+    system.load_binary_at(0x0200, bytes([0x02]))
 
     with pytest.raises(InvalidOPCode, match="0x02"):
         system.run_cycles(10)
@@ -64,7 +64,7 @@ def test_nop_mode_skips_invalid_opcode(system) -> None:
     system.set_invalid_opcode_mode(0)  # NOP mode
 
     # 0x02 (invalid) followed by NOP NOP
-    system.load_binary("RAM", 0x0200, bytes([0x02, 0xEA, 0xEA]))
+    system.load_binary_at(0x0200, bytes([0x02, 0xEA, 0xEA]))
 
     system.run_cycles(10)
 
@@ -77,8 +77,8 @@ def test_nop_mode_skips_invalid_opcode(system) -> None:
 def test_crash_mode_includes_address_in_message(system) -> None:
     """Crash mode error message includes both opcode and address."""
     # JMP $0300, then invalid opcode at $0300
-    system.load_binary("RAM", 0x0200, bytes([0x4C, 0x00, 0x03]))
-    system.load_binary("RAM", 0x0300, bytes([0x02]))
+    system.load_binary_at(0x0200, bytes([0x4C, 0x00, 0x03]))
+    system.load_binary_at(0x0300, bytes([0x02]))
 
     with pytest.raises(InvalidOPCode, match="0x0300"):
         system.run_cycles(20)

--- a/tests/test_runtime_load_binary.py
+++ b/tests/test_runtime_load_binary.py
@@ -1,0 +1,122 @@
+"""
+Tests for ``System.load_binary_at`` (issue #57) — the runtime counterpart
+to config-time binary loading.
+
+Mirrors the coverage cases in ``test_binaries.py`` but exercises an
+already-constructed ``System`` instead of going through the loader. Both
+paths share ``validate_coverage`` in ``loader.py``, so these tests pin
+the runtime side of that contract.
+"""
+from __future__ import annotations
+
+import pytest
+
+from py6502.sim.system import (
+    ConfigError,
+    CpuSpec,
+    MemoryRegion,
+    System,
+    SystemConfig,
+)
+
+
+def _make_system(*memory: MemoryRegion) -> System:
+    config = SystemConfig(
+        version=1, id="rt", name="RT", description="",
+        cpu=CpuSpec(type="MOS6502", hz=1_000_000),
+        memory=memory,
+    )
+    return System(config)
+
+
+def test_load_into_single_region() -> None:
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    payload = bytes(range(16))
+    system.load_binary_at(0x0100, payload)
+    for i, byte in enumerate(payload):
+        assert system.peek(0x0100 + i) == byte
+    # Neighbours untouched.
+    assert system.peek(0x00FF) == 0x00
+    assert system.peek(0x0110) == 0x00
+
+
+def test_load_spans_two_contiguous_regions() -> None:
+    system = _make_system(
+        MemoryRegion(name="RAM", start=0x0000, size=0x1000),
+        MemoryRegion(name="ROM", start=0x1000, size=0x0100, read_only=True),
+    )
+    payload = bytes(i & 0xFF for i in range(0x100))
+    system.load_binary_at(0x0F80, payload)
+    assert system.peek(0x0F80) == payload[0]
+    assert system.peek(0x1000) == payload[0x1000 - 0x0F80]
+    assert system.peek(0x0F80 + 0x100 - 1) == payload[-1]
+
+
+def test_load_address_outside_any_region_rejected() -> None:
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    with pytest.raises(
+        ConfigError,
+        match=r"load_binary_at:.*not inside any memory region",
+    ):
+        system.load_binary_at(0x8000, bytes([0xEA] * 4))
+
+
+def test_load_extending_past_mapped_range_rejected() -> None:
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    with pytest.raises(ConfigError, match=r"load_binary_at:.*extends past"):
+        system.load_binary_at(0x0F80, bytes([0xEA] * 0x100))
+
+
+def test_load_crossing_an_unmapped_gap_rejected() -> None:
+    # Regions at 0x0000-0x0FFF and 0x2000-0x20FF leave a gap. A 0x400-byte
+    # load at 0x0F80 starts inside RAM, tails into the HI region at 0x2000,
+    # and crosses the gap between them.
+    system = _make_system(
+        MemoryRegion(name="LO", start=0x0000, size=0x1000),
+        MemoryRegion(name="HI", start=0x2000, size=0x0100),
+    )
+    with pytest.raises(
+        ConfigError,
+        match=r"load_binary_at:.*crosses an unmapped gap",
+    ):
+        system.load_binary_at(0x0F80, bytes([0xEA] * 0x1100))
+
+
+def test_load_zero_bytes_rejected() -> None:
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    with pytest.raises(ConfigError, match=r"load_binary_at:.*zero bytes"):
+        system.load_binary_at(0x0000, b"")
+
+
+def test_load_address_above_bus_width_rejected() -> None:
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    with pytest.raises(
+        ConfigError,
+        match=r"load_binary_at:.*outside the 16-bit bus",
+    ):
+        system.load_binary_at(0x10000, bytes([0xEA]))
+
+
+def test_load_into_read_only_region_succeeds() -> None:
+    """
+    Runtime loads match config-time precedent: writing through
+    ``Memory.set_data`` bypasses the ``read_only`` flag. Loading a ROM
+    image at runtime is intentional, not a bug.
+    """
+    system = _make_system(
+        MemoryRegion(name="ROM", start=0xFF00, size=0x0100, read_only=True),
+    )
+    payload = bytes([0xEE] * 0x10)
+    system.load_binary_at(0xFF00, payload)
+    assert system.peek(0xFF00) == 0xEE
+    assert system.peek(0xFF0F) == 0xEE
+
+
+def test_load_overwrites_previous_load() -> None:
+    """Runtime overwrites are allowed — there's no binary-vs-binary overlap
+    check at this layer (unlike config time)."""
+    system = _make_system(MemoryRegion(name="RAM", start=0x0000, size=0x1000))
+    system.load_binary_at(0x0100, bytes([0xAA] * 4))
+    system.load_binary_at(0x0100, bytes([0xBB] * 4))
+    assert system.peek(0x0100) == 0xBB
+    assert system.peek(0x0103) == 0xBB

--- a/tests/test_system_smoke.py
+++ b/tests/test_system_smoke.py
@@ -35,7 +35,7 @@ def test_apple1_boots_and_renders() -> None:
 def test_load_binary_round_trip() -> None:
     system = System.from_yaml_file(APPLE1_PRESET)
     payload = bytes([0xEA, 0xEA, 0x4C, 0x00, 0x02])  # NOP NOP JMP $0200
-    system.load_binary("RAM", 0x0200, payload)
+    system.load_binary_at(0x0200, payload)
 
     for i, byte in enumerate(payload):
         assert system.peek(0x0200 + i) == byte

--- a/tests/test_unmapped_memory.py
+++ b/tests/test_unmapped_memory.py
@@ -48,7 +48,7 @@ def test_crash_mode_raises_during_run_cycles(system) -> None:
     system.set_unmapped_memory_mode(True)
 
     # JMP $5000 — CPU will try to fetch from unmapped address
-    system.load_binary("RAM", 0x0200, bytes([0x4C, 0x00, 0x50]))
+    system.load_binary_at(0x0200, bytes([0x4C, 0x00, 0x50]))
     regs = system.get_registers()
     regs["PC"] = 0x0200
     regs["INTERRUPT_TYPE"] = 0


### PR DESCRIPTION
## Summary
- Extract `validate_coverage(memory, bus, address, length, *, label)` from `_validate_binaries` in `loader.py`; the config-time validator keeps its bus-declared and binary-overlap checks but delegates the coverage logic so the runtime path reuses the exact same Rule-13 rejections.
- Add `System.load_binary_at(address, data)` that calls `validate_coverage` with `label="load_binary_at"` and slices bytes across the returned regions the same way `System.__init__` does. Delete the region-name + offset `load_binary` and migrate all three test callers.
- Rewrite `src/py6502/ui/windows/binaryloader.py`: drop the region dropdown, take an absolute hex address, call `load_binary_at`, surface `ConfigError` messages in the existing status bar.
- Sync `docs/ROADMAP.md` open-issue list for v0.1 (closed #42 out, open #57 in). Update `docs/ARCHITECTURE.md`, `docs/SYSTEM_CONFIG.md`, `sim/README.md`, `ui/CLAUDE.md`, and `sim-perf-reviewer.md` for the renamed API.

## Why
After PR #56 the custom system builder already expressed binaries as `BinarySource{source, address, bus}` and validated them with Rule 13, but the runtime Load Binary dialog still used region-name + offset, with a separate error shape. Two mental models for "load a binary" is one too many, and the drift between the two paths would have grown as #51 (bundled-asset picker) lands next. Extracting `validate_coverage` into a shared helper means both paths stay aligned by construction — there's one copy of the Rule-13 wording, not two.

The file-picker extraction that #57 also mentioned is deferred to #51, where the real shared concept is "binary source" (filesystem vs. bundled), not "file dialog". The two existing `dpg.file_dialog` blocks stay as-is for now.

## Test plan
- [x] `pip install -e .` rebuilds Cython cleanly.
- [x] `pytest` — 71 passed, including 9 new cases in `tests/test_runtime_load_binary.py` (single region, two-region span, outside any region, extends past, crosses gap, zero bytes, address > 0xFFFF, read-only region, overwrite) and the existing `test_binaries.py` Rule-13 substring assertions unchanged.
- [x] `python -m py6502` — Load Binary dialog takes an address, succeeds at mapped addresses (e.g. 0xFF00 on the Apple 1 preset), and surfaces Rule-13-shape errors for unmapped / out-of-range / gap-crossing loads.
- [x] Custom system builder unchanged and still functional (address-based binaries path from PR #56).

## Closes
Closes #57