### PR TITLE
Add binary source picker with bundled-asset manifest

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,7 +64,6 @@ wrong here, every later release pays for it.
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
 - [#51](https://github.com/ricky-groenewald/py6502/issues/51) — Binary source picker: filesystem vs bundled assets, backed by an asset manifest
-- [#57](https://github.com/ricky-groenewald/py6502/issues/57) — Migrate runtime Load Binary window to address-based model
 
 **Explicit non-goals for v0.1.**
 

--- a/src/py6502/sim/assets/manifest.yaml
+++ b/src/py6502/sim/assets/manifest.yaml
@@ -1,0 +1,7 @@
+version: 1
+binaries:
+  - name: apple1-wozmon
+    description: Apple 1 Wozmon monitor
+    source: resource:py6502.sim.assets.bios/apple1-wozmon.bin
+    default_address: 0xFF00
+    tags: [apple1, monitor]

--- a/src/py6502/sim/manifest.py
+++ b/src/py6502/sim/manifest.py
@@ -1,0 +1,85 @@
+"""
+Bundled-asset manifest.
+
+``list_binaries()`` returns the binaries shipped under
+``py6502.sim.assets/`` according to ``assets/manifest.yaml``. The UI
+uses it to populate the "Bundled" side of the binary-source picker;
+tests use it as a stable reference to the wozmon ROM without
+hard-coding filesystem paths.
+
+The manifest is loaded exactly once on first access.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from importlib import resources
+
+import yaml
+
+
+SUPPORTED_MANIFEST_VERSIONS = (1,)
+
+
+@dataclass(frozen=True)
+class BinaryAsset:
+    name: str
+    description: str
+    source: str
+    default_address: int
+    tags: tuple[str, ...] = ()
+    size_bytes: int = 0
+
+    def data(self) -> bytes:
+        """Return the asset's raw bytes. Only ``resource:`` URIs are supported."""
+        if not self.source.startswith("resource:"):
+            raise ValueError(
+                f"BinaryAsset.data only handles resource: URIs, got {self.source!r}"
+            )
+        body = self.source[len("resource:") :]
+        package, _, filename = body.partition("/")
+        if not filename:
+            raise ValueError(
+                f"malformed resource URI {self.source!r} "
+                f"— expected 'resource:<package>/<filename>'"
+            )
+        return resources.files(package).joinpath(filename).read_bytes()
+
+
+@lru_cache(maxsize=1)
+def list_binaries() -> tuple[BinaryAsset, ...]:
+    """Return the bundled binaries described by the asset manifest."""
+    text = (
+        resources.files("py6502.sim.assets").joinpath("manifest.yaml").read_text()
+    )
+    raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        raise ValueError("manifest.yaml top-level must be a mapping")
+
+    version = raw.get("version")
+    if version not in SUPPORTED_MANIFEST_VERSIONS:
+        supported = ", ".join(str(v) for v in SUPPORTED_MANIFEST_VERSIONS)
+        raise ValueError(
+            f"unsupported manifest version {version!r}; supported: {supported}"
+        )
+
+    entries = raw.get("binaries")
+    if not isinstance(entries, list):
+        raise ValueError("manifest.yaml 'binaries' must be a list")
+
+    out: list[BinaryAsset] = []
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"manifest binaries[{i}] must be a mapping")
+        source = str(entry["source"])
+        asset = BinaryAsset(
+            name=str(entry["name"]),
+            description=str(entry["description"]),
+            source=source,
+            default_address=int(entry["default_address"]),
+            tags=tuple(entry.get("tags") or ()),
+        )
+        # Eagerly resolve size so the UI can show it without re-reading
+        # the resource on every combo change. Manifest is small in v0.1.
+        out.append(replace(asset, size_bytes=len(asset.data())))
+    return tuple(out)

--- a/src/py6502/ui/widgets/__init__.py
+++ b/src/py6502/ui/widgets/__init__.py
@@ -1,0 +1,4 @@
+"""Reusable UI widgets composed by `windows/` panels."""
+from .binary_source_picker import BinarySourcePicker
+
+__all__ = ["BinarySourcePicker"]

--- a/src/py6502/ui/widgets/binary_source_picker.py
+++ b/src/py6502/ui/widgets/binary_source_picker.py
@@ -1,0 +1,206 @@
+"""Shared "binary source" picker — a file on disk or a bundled asset."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import dearpygui.dearpygui as dpg
+
+from py6502.sim.manifest import BinaryAsset, list_binaries
+
+
+def _format_size(n: int) -> str:
+    return f"{n} B (0x{n:X})"
+
+
+def _describe(asset: BinaryAsset) -> str:
+    return f"Size: {_format_size(asset.size_bytes)}\n{asset.description}"
+
+
+class BinarySourcePicker:
+    """
+    Renders a "From disk / Bundled" toggle plus the corresponding input
+    widgets. Used by the runtime Load Binary dialog (one instance per
+    window) and by the custom-system builder (one instance per binary
+    row). Each instance owns a distinct tag prefix so multiple pickers
+    coexist on the same screen.
+
+    The picker returns a URI in the same shape as
+    ``BinarySource.source`` — ``file:<abspath>`` or
+    ``resource:<package>/<filename>`` — so the config-time and runtime
+    binary-loading paths both accept it unchanged.
+    """
+
+    def __init__(
+        self,
+        tag_prefix: str,
+        *,
+        path_width: int = 260,
+        combo_width: int = 180,
+        desc_wrap: int = 500,
+        on_asset_selected: Callable[[BinaryAsset], None] | None = None,
+    ) -> None:
+        self._prefix = tag_prefix
+        self._path_width = path_width
+        self._combo_width = combo_width
+        self._desc_wrap = desc_wrap
+        self._on_asset_selected = on_asset_selected
+
+        self._assets: tuple[BinaryAsset, ...] = ()
+        self._disk_path: str = ""
+        self._selected_asset: BinaryAsset | None = None
+
+    @property
+    def _mode_tag(self) -> str:
+        return f"{self._prefix}Mode"
+
+    @property
+    def _disk_group_tag(self) -> str:
+        return f"{self._prefix}DiskGroup"
+
+    @property
+    def _bundled_group_tag(self) -> str:
+        return f"{self._prefix}BundledGroup"
+
+    @property
+    def _path_tag(self) -> str:
+        return f"{self._prefix}Path"
+
+    @property
+    def _combo_tag(self) -> str:
+        return f"{self._prefix}Combo"
+
+    @property
+    def _desc_tag(self) -> str:
+        return f"{self._prefix}Desc"
+
+    @property
+    def _dialog_tag(self) -> str:
+        return f"{self._prefix}FileDialog"
+
+    def build(self) -> None:
+        """Render the picker into the current DPG container."""
+        self._assets = list_binaries()
+        if self._assets:
+            self._selected_asset = self._assets[0]
+
+        dpg.add_radio_button(
+            tag=self._mode_tag,
+            items=["From disk", "Bundled"],
+            default_value="From disk",
+            horizontal=True,
+            callback=self._on_mode_changed,
+        )
+
+        with dpg.group(tag=self._disk_group_tag):
+            with dpg.group(horizontal=True):
+                dpg.add_input_text(
+                    tag=self._path_tag,
+                    readonly=True,
+                    width=self._path_width,
+                    hint="No file selected",
+                )
+                dpg.add_button(label="Browse...", callback=self._on_browse)
+
+        with dpg.group(tag=self._bundled_group_tag, show=False):
+            with dpg.group(horizontal=True):
+                items = [a.name for a in self._assets]
+                dpg.add_combo(
+                    tag=self._combo_tag,
+                    items=items,
+                    default_value=items[0] if items else "",
+                    width=self._combo_width,
+                    callback=self._on_combo_changed,
+                )
+            dpg.add_text(
+                _describe(self._assets[0]) if self._assets else "",
+                tag=self._desc_tag,
+                color=(180, 180, 180),
+                wrap=self._desc_wrap,
+            )
+
+        with dpg.file_dialog(
+            directory_selector=False,
+            show=False,
+            callback=self._on_file_selected,
+            tag=self._dialog_tag,
+            width=700,
+            height=400,
+        ):
+            dpg.add_file_extension(".bin", color=(0, 255, 0, 255))
+            dpg.add_file_extension(".rom", color=(0, 255, 0, 255))
+            dpg.add_file_extension(".*")
+
+    def destroy(self) -> None:
+        """Delete the file dialog this picker owns. Call before the group
+        containing the picker is itself deleted — DPG file dialogs are
+        registered at the top level and would otherwise leak."""
+        if dpg.does_item_exist(self._dialog_tag):
+            dpg.delete_item(self._dialog_tag)
+
+    def reset(self) -> None:
+        """Clear any selection and reset the toggle to 'From disk'."""
+        self._disk_path = ""
+        if dpg.does_item_exist(self._path_tag):
+            dpg.set_value(self._path_tag, "")
+            dpg.set_value(self._mode_tag, "From disk")
+            dpg.configure_item(self._disk_group_tag, show=True)
+            dpg.configure_item(self._bundled_group_tag, show=False)
+            if self._assets:
+                self._selected_asset = self._assets[0]
+                dpg.set_value(self._combo_tag, self._assets[0].name)
+                dpg.set_value(self._desc_tag, _describe(self._assets[0]))
+
+    def is_empty(self) -> bool:
+        if dpg.get_value(self._mode_tag) == "From disk":
+            return not self._disk_path
+        return self._selected_asset is None
+
+    def get_source(self) -> tuple[str, int | None]:
+        """Return ``(uri, prefill_address_or_None)``. Raises ``ValueError``
+        if nothing is selected."""
+        if dpg.get_value(self._mode_tag) == "From disk":
+            if not self._disk_path:
+                raise ValueError("No file selected")
+            return f"file:{self._disk_path}", None
+        if self._selected_asset is None:
+            raise ValueError("No bundled asset selected")
+        return self._selected_asset.source, self._selected_asset.default_address
+
+    def get_bytes(self) -> bytes:
+        """Return the selected binary's raw bytes."""
+        if dpg.get_value(self._mode_tag) == "From disk":
+            if not self._disk_path:
+                raise ValueError("No file selected")
+            return Path(self._disk_path).read_bytes()
+        if self._selected_asset is None:
+            raise ValueError("No bundled asset selected")
+        return self._selected_asset.data()
+
+    def _on_mode_changed(self, sender: int, app_data: str, user_data: object) -> None:
+        if app_data == "From disk":
+            dpg.configure_item(self._disk_group_tag, show=True)
+            dpg.configure_item(self._bundled_group_tag, show=False)
+            return
+        dpg.configure_item(self._disk_group_tag, show=False)
+        dpg.configure_item(self._bundled_group_tag, show=True)
+        if self._selected_asset is not None and self._on_asset_selected is not None:
+            self._on_asset_selected(self._selected_asset)
+
+    def _on_browse(self) -> None:
+        dpg.show_item(self._dialog_tag)
+
+    def _on_file_selected(self, sender: int, app_data: dict, user_data: object) -> None:
+        path = app_data.get("file_path_name", "")
+        if path:
+            self._disk_path = path
+            dpg.set_value(self._path_tag, path)
+
+    def _on_combo_changed(self, sender: int, app_data: str, user_data: object) -> None:
+        asset = next((a for a in self._assets if a.name == app_data), None)
+        if asset is None:
+            return
+        self._selected_asset = asset
+        dpg.set_value(self._desc_tag, _describe(asset))
+        if self._on_asset_selected is not None:
+            self._on_asset_selected(asset)

--- a/src/py6502/ui/windows/binaryloader.py
+++ b/src/py6502/ui/windows/binaryloader.py
@@ -1,45 +1,43 @@
-"""Binary loader dialog — load a .bin/.rom file at an absolute address."""
+"""Binary loader dialog — load a .bin/.rom file (or a bundled asset) at an absolute address."""
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import dearpygui.dearpygui as dpg
+
+from py6502.sim.manifest import BinaryAsset
+from py6502.ui.widgets import BinarySourcePicker
 
 if TYPE_CHECKING:
     from py6502.ui.app import Py6502App
 
 WINDOW_TAG = "BinaryLoaderWindow"
-FILE_PATH_TAG = "BinaryLoaderFilePath"
 ADDRESS_TAG = "BinaryLoaderAddress"
 STATUS_TAG = "BinaryLoaderStatus"
-FILE_DIALOG_TAG = "BinaryLoaderFileDialog"
+PICKER_PREFIX = "BinaryLoaderSource"
 
 
 class BinaryLoaderWindow:
     def __init__(self, app: Py6502App) -> None:
         self._app = app
-        self._file_path: str = ""
+        self._picker = BinarySourcePicker(
+            PICKER_PREFIX,
+            path_width=300,
+            combo_width=200,
+            desc_wrap=420,
+            on_asset_selected=self._on_asset_selected,
+        )
 
     def build(self) -> None:
         with dpg.window(
             label="Load Binary",
             width=500,
-            height=180,
+            height=220,
             show=False,
             tag=WINDOW_TAG,
         ):
-            # File selection row
-            with dpg.group(horizontal=True):
-                dpg.add_input_text(
-                    tag=FILE_PATH_TAG,
-                    readonly=True,
-                    width=380,
-                    hint="No file selected",
-                )
-                dpg.add_button(label="Browse...", callback=self._on_browse)
+            self._picker.build()
 
-            # Address row
             with dpg.group(horizontal=True):
                 dpg.add_text("Address: 0x")
                 dpg.add_input_text(
@@ -51,64 +49,38 @@ class BinaryLoaderWindow:
                     no_spaces=True,
                 )
 
-            # Action buttons
             with dpg.group(horizontal=True):
                 dpg.add_button(label="Load", callback=self._on_load)
                 dpg.add_button(label="Cancel", callback=self._on_cancel)
 
-            # Status text
             dpg.add_text("", tag=STATUS_TAG)
 
-        # File dialog
-        with dpg.file_dialog(
-            directory_selector=False,
-            show=False,
-            callback=self._on_file_selected,
-            tag=FILE_DIALOG_TAG,
-            width=700,
-            height=400,
-        ):
-            dpg.add_file_extension(".bin", color=(0, 255, 0, 255))
-            dpg.add_file_extension(".rom", color=(0, 255, 0, 255))
-            dpg.add_file_extension(".*")
-
     def show(self) -> None:
-        self._file_path = ""
-        dpg.set_value(FILE_PATH_TAG, "")
+        self._picker.reset()
         dpg.set_value(ADDRESS_TAG, "0000")
         dpg.set_value(STATUS_TAG, "")
         dpg.configure_item(STATUS_TAG, color=(255, 255, 255))
         dpg.show_item(WINDOW_TAG)
 
-    # ------------------------------------------------------------------
-    # Callbacks
-    # ------------------------------------------------------------------
-    def _on_browse(self) -> None:
-        dpg.show_item(FILE_DIALOG_TAG)
-
-    def _on_file_selected(self, sender: int, app_data: dict, user_data: object) -> None:
-        file_path = app_data.get("file_path_name", "")
-        if file_path:
-            self._file_path = file_path
-            dpg.set_value(FILE_PATH_TAG, file_path)
+    def _on_asset_selected(self, asset: BinaryAsset) -> None:
+        dpg.set_value(ADDRESS_TAG, f"{asset.default_address:04X}")
 
     def _on_load(self) -> None:
         if self._app.system is None:
             return
 
-        if not self._file_path:
-            self._set_status("No file selected", error=True)
+        if self._picker.is_empty():
+            self._set_status("No binary selected", error=True)
             return
 
-        address_str = dpg.get_value(ADDRESS_TAG)
         try:
-            address = int(address_str, 16)
+            address = int(dpg.get_value(ADDRESS_TAG), 16)
         except ValueError:
             self._set_status("Invalid address value", error=True)
             return
 
         try:
-            data = Path(self._file_path).read_bytes()
+            data = self._picker.get_bytes()
             self._app.system.load_binary_at(address, data)
         except Exception as exc:
             self._set_status(str(exc), error=True)

--- a/src/py6502/ui/windows/systemselector.py
+++ b/src/py6502/ui/windows/systemselector.py
@@ -18,10 +18,12 @@ from py6502.sim.system import (
     to_yaml_text,
     write_yaml_file,
 )
+from py6502.sim.manifest import BinaryAsset
 from py6502.sim.system.loader import from_yaml_text
 from py6502.ui.utils import paths
 from py6502.ui.utils.presets import discover_presets, load_user_config_metadata
 from py6502.ui.utils.settings import save_settings
+from py6502.ui.widgets import BinarySourcePicker
 
 if TYPE_CHECKING:
     from py6502.ui.app import Py6502App
@@ -84,7 +86,6 @@ CUSTOM_DISPLAY_ADDR_TAG = "CustomSystemDisplayAddr"
 CUSTOM_INPUT_TAG = "CustomSystemInput"
 CUSTOM_INPUT_ADDR_TAG = "CustomSystemInputAddr"
 CUSTOM_STATUS_TAG = "CustomSystemStatus"
-SOURCE_FILE_DIALOG_TAG = "CustomSystemSourceFileDialog"
 
 
 class SystemSelectorWindow:
@@ -97,7 +98,7 @@ class SystemSelectorWindow:
         self._region_ids: list[int] = []
         self._binary_counter = 0
         self._binary_ids: list[int] = []
-        self._source_dialog_target: int | None = None
+        self._binary_pickers: dict[int, BinarySourcePicker] = {}
         # Per-preset option selections, keyed by preset path. Persists across
         # re-selects so the user's picks stick if they navigate away and back.
         self._option_values: dict[str, dict[str, object]] = {}
@@ -138,15 +139,6 @@ class SystemSelectorWindow:
         ):
             dpg.add_file_extension(".yaml", color=(0, 255, 0, 255))
             dpg.add_file_extension(".yml", color=(0, 255, 0, 255))
-
-        with dpg.file_dialog(
-            directory_selector=False, show=False,
-            callback=self._on_source_file_selected, tag=SOURCE_FILE_DIALOG_TAG,
-            width=700, height=400,
-        ):
-            dpg.add_file_extension(".bin", color=(0, 255, 0, 255))
-            dpg.add_file_extension(".rom", color=(0, 255, 0, 255))
-            dpg.add_file_extension(".*")
 
         with dpg.window(
             label="Remove user config",
@@ -278,26 +270,26 @@ class SystemSelectorWindow:
             self._region_ids.remove(rid)
             dpg.delete_item(f"CustomRegion_{rid}")
 
-    def _add_binary(self, path: str = "", address: str = "0000") -> None:
+    def _add_binary(self) -> None:
         bid = self._binary_counter
         self._binary_counter += 1
         self._binary_ids.append(bid)
 
+        picker = BinarySourcePicker(
+            f"CustomBinary{bid}_",
+            path_width=220,
+            combo_width=180,
+            desc_wrap=380,
+            on_asset_selected=lambda asset, _bid=bid: self._prefill_binary_address(_bid, asset),
+        )
+        self._binary_pickers[bid] = picker
+
         with dpg.group(tag=f"CustomBinary_{bid}", parent=CUSTOM_BINARIES_TAG):
+            picker.build()
             with dpg.group(horizontal=True):
-                dpg.add_input_text(
-                    tag=f"BinarySource_{bid}", readonly=True,
-                    default_value=path,
-                    width=260, hint="Binary file",
-                )
-                dpg.add_button(
-                    label="Browse...",
-                    callback=lambda s, a, u: self._browse_source(u),
-                    user_data=bid,
-                )
                 dpg.add_text(" @ 0x")
                 dpg.add_input_text(
-                    tag=f"BinaryAddr_{bid}", default_value=address,
+                    tag=f"BinaryAddr_{bid}", default_value="0000",
                     width=60, uppercase=True, hexadecimal=True, no_spaces=True,
                 )
                 dpg.add_button(
@@ -305,20 +297,19 @@ class SystemSelectorWindow:
                     callback=lambda s, a, u: self._remove_binary(u),
                     user_data=bid,
                 )
+            dpg.add_separator()
+
+    def _prefill_binary_address(self, bid: int, asset: BinaryAsset) -> None:
+        if dpg.does_item_exist(f"BinaryAddr_{bid}"):
+            dpg.set_value(f"BinaryAddr_{bid}", f"{asset.default_address:04X}")
 
     def _remove_binary(self, bid: int) -> None:
         if bid in self._binary_ids:
+            picker = self._binary_pickers.pop(bid, None)
+            if picker is not None:
+                picker.destroy()
             self._binary_ids.remove(bid)
             dpg.delete_item(f"CustomBinary_{bid}")
-
-    def _browse_source(self, bid: int) -> None:
-        self._source_dialog_target = bid
-        dpg.show_item(SOURCE_FILE_DIALOG_TAG)
-
-    def _on_source_file_selected(self, sender: int, app_data: dict, user_data: object) -> None:
-        file_path = app_data.get("file_path_name", "")
-        if file_path and self._source_dialog_target is not None:
-            dpg.set_value(f"BinarySource_{self._source_dialog_target}", file_path)
 
     def _reset_custom_form(self) -> None:
         for rid in list(self._region_ids):
@@ -656,16 +647,17 @@ class SystemSelectorWindow:
     def _collect_binaries(self) -> tuple[BinarySource, ...] | None:
         out: list[BinarySource] = []
         for bid in self._binary_ids:
-            path = dpg.get_value(f"BinarySource_{bid}").strip()
-            if not path:
+            picker = self._binary_pickers[bid]
+            if picker.is_empty():
                 self._set_status("A binary source has no file selected", error=True)
                 return None
             try:
                 addr = int(dpg.get_value(f"BinaryAddr_{bid}"), 16)
             except ValueError:
-                self._set_status(f"Invalid hex address for binary '{path}'", error=True)
+                self._set_status("Invalid hex address for a binary", error=True)
                 return None
-            out.append(BinarySource(source=f"file:{path}", address=addr))
+            uri, _prefill = picker.get_source()
+            out.append(BinarySource(source=uri, address=addr))
         return tuple(out)
 
     def _collect_display(self) -> ComponentSpec | None | bool:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,51 @@
+"""
+Tests for ``py6502.sim.manifest`` — the bundled-asset manifest loader.
+
+Covers the Python-side contract: ``list_binaries()`` returns a tuple of
+``BinaryAsset`` records sourced from ``assets/manifest.yaml``, and
+``BinaryAsset.data()`` reads bytes back via ``importlib.resources``
+against the same ``resource:`` URI shape the YAML loader uses.
+"""
+from __future__ import annotations
+
+from py6502.sim.manifest import BinaryAsset, list_binaries
+
+
+def test_list_binaries_exposes_wozmon() -> None:
+    assets = list_binaries()
+    assert isinstance(assets, tuple)
+    names = {a.name for a in assets}
+    assert "apple1-wozmon" in names
+
+    wozmon = next(a for a in assets if a.name == "apple1-wozmon")
+    assert wozmon.default_address == 0xFF00
+    assert wozmon.source == "resource:py6502.sim.assets.bios/apple1-wozmon.bin"
+    assert wozmon.size_bytes == 256
+    assert "apple1" in wozmon.tags
+
+
+def test_binary_asset_data_returns_rom_bytes() -> None:
+    wozmon = next(a for a in list_binaries() if a.name == "apple1-wozmon")
+    data = wozmon.data()
+    assert isinstance(data, bytes)
+    assert len(data) == 256  # wozmon ROM is exactly one page
+
+
+def test_list_binaries_is_cached() -> None:
+    """Repeated calls return the same tuple object — the manifest is read once."""
+    assert list_binaries() is list_binaries()
+
+
+def test_binary_asset_data_rejects_non_resource_uri() -> None:
+    asset = BinaryAsset(
+        name="x",
+        description="",
+        source="file:/tmp/does-not-exist.bin",
+        default_address=0,
+    )
+    try:
+        asset.data()
+    except ValueError as exc:
+        assert "resource:" in str(exc)
+    else:  # pragma: no cover — the call above is expected to raise
+        raise AssertionError("expected ValueError for non-resource URI")

--- a/tests/test_runtime_load_binary.py
+++ b/tests/test_runtime_load_binary.py
@@ -112,6 +112,20 @@ def test_load_into_read_only_region_succeeds() -> None:
     assert system.peek(0xFF0F) == 0xEE
 
 
+def test_load_bundled_wozmon_via_manifest() -> None:
+    """Bundled wozmon asset round-trips through the manifest API → load_binary_at."""
+    from py6502.sim.manifest import list_binaries
+
+    wozmon = next(a for a in list_binaries() if a.name == "apple1-wozmon")
+    system = _make_system(
+        MemoryRegion(name="ROM", start=0xFF00, size=0x0100, read_only=True),
+    )
+    data = wozmon.data()
+    system.load_binary_at(wozmon.default_address, data)
+    assert system.peek(0xFF00) == data[0]
+    assert system.peek(0xFFFF) == data[-1]
+
+
 def test_load_overwrites_previous_load() -> None:
     """Runtime overwrites are allowed — there's no binary-vs-binary overlap
     check at this layer (unlike config time)."""


### PR DESCRIPTION
## Summary
- New `py6502.sim.manifest` module exposes `BinaryAsset` + `list_binaries()` backed by `src/py6502/sim/assets/manifest.yaml` (wozmon only for v0.1); `size_bytes` is populated eagerly so UI reads don't retouch the resource.
- New `py6502.ui.widgets.BinarySourcePicker` renders a "From disk / Bundled" toggle and returns a `file:` / `resource:` URI in the same shape as `BinarySource.source`, so both config-time and runtime loading paths accept it unchanged.
- Runtime Load Binary dialog and the custom-system builder's binary rows both use the picker; selecting a bundled asset prefills the load address.
- `tests/test_manifest.py` plus an extra case in `test_runtime_load_binary.py` cover the sim-side API end-to-end (76 tests passing).
- ROADMAP bullet for the already-closed #57 removed so v0.1's open-issue list matches GitHub.

## Why
PRs #42/#56/#58 converged config-time and runtime binary loading onto a single address-based model, but both UI surfaces still assumed a filesystem path. This finishes the convergence from the user's side: bundled ROMs (starting with wozmon) become a first-class source, with a documented manifest as their home instead of being implicit under `assets/`. The picker widget is shared between the two windows so there's one mental model for "pick a binary" and no duplication of the dialog plumbing.

Keeping the API on a sibling `py6502.sim.manifest` module — rather than making `assets/` a regular Python package — preserves the data-only convention and avoids cascading `__init__.py` files into every asset subdirectory.

## Test plan
- [x] `pip install -e .` rebuilds cleanly
- [x] `pytest` — 76 passed (4 new manifest tests + 1 new runtime case)
- [x] `python -m py6502`: Apple 1 preset → Load Binary → "From disk / Bundled" toggle; Bundled → wozmon prefills `0xFF00` and shows size; Load succeeds
- [x] Custom system builder → Add Binary → per-row toggle; Bundled and Disk paths both launch; Rule-13 errors still surface in red

## Closes
Closes #51