### PR TITLE
Polish comments, READMEs, and docs for v0.1 release

### DIFF
--- a/.claude/skills/new-peripheral/SKILL.md
+++ b/.claude/skills/new-peripheral/SKILL.md
@@ -146,7 +146,6 @@ it off:
 - **Do not run `pip install -e .`.** The checklist tells the human to do
   it. Build side-effects from a scaffolding skill cause more problems
   than they solve.
-- **Do not touch the legacy `py6502ui.py`.**
 
 ## References
 
@@ -156,7 +155,10 @@ it off:
   `System`.
 - `docs/SYSTEM_CONFIG.md` — the IaC config format and the component
   registry shape.
-- `src/py6502/sim/peripherals/apple1.pyx` — the canonical example of a
-  peripheral, warts and all. Note that its `clock()` method is a v0.1
-  anti-pattern that will be removed; do not copy that loop shape into
-  new work.
+- `src/py6502/sim/peripherals/apple1_display.pyx` — the canonical
+  reference for a peripheral with hardware-observable timing
+  (DSP busy bit, batch-end tick hook, `bind()` wiring against
+  `cpu_hz`).
+- `src/py6502/sim/peripherals/apple1_keyboard.pyx` — the canonical
+  reference for an input peripheral (FIFO buffer, `send_input` /
+  `clear_input` overrides).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,3 @@ play/                  Scratch 6502 asm + binaries; not part of the package
 
 - `play/` — Ricky's scratchpad. Don't normalise or refactor anything under
   it; treat it as read-only input data.
-- `src/py6502/ui/py6502ui.py` — the legacy monolithic UI. It stays as a
-  feature-parity reference until the new `Py6502App` shell replaces it in
-  v0.1. Don't port new features into it.

--- a/README.md
+++ b/README.md
@@ -21,20 +21,25 @@ with an integrated assembler, snippet editor, and sprite tools. See
 ## Status
 
 v0.1 is in active development. It ships a cycle-accurate 6502, the Apple I
-preset, a debug panel with step-level debugging, a system selector, a
-binary loader, and configurable settings.
+preset (with bundled wozmon ROM and Sphere font), a system selector with
+preset / user-config / custom-system pickers, a debug panel with
+step-level debugging and a memory monitor, a runtime binary loader, and
+configurable settings.
 
 ## Prerequisites
 
 - **Python 3.12+**
 - A C toolchain capable of building Cython extensions
-- **Custom DearPyGui build** — py6502 uses a patched DearPyGui with
-  `GL_LINEAR` replaced by `GL_NEAREST` to disable texture filtering for
-  pixel-accurate rendering. Without this patch, the 256x240 framebuffer
-  appears blurry when scaled. See
+- **Custom DearPyGui build (required, BYO)** — py6502 uses a patched
+  DearPyGui with `GL_LINEAR` swapped for `GL_NEAREST` so the 256×240
+  framebuffer scales without the default linear filter blurring it. The
+  patch is a one-line C++ change inside DearPyGui's GL renderer; see
   [DearPyGui#773](https://github.com/hoffstadt/DearPyGui/issues/773) for
-  context and the workaround details (search for the `GL_NEAREST` fix in
-  the issue discussion).
+  the discussion and the snippet to apply. Build DearPyGui from source
+  with the patch and `pip install` the resulting wheel into the same
+  environment you run py6502 from. (DearPyGui is intentionally not
+  declared as a `pip` dependency in `pyproject.toml` so a stock wheel
+  doesn't get pulled in by accident.)
 
 ## Install and run
 
@@ -132,7 +137,7 @@ Before opening a PR:
 2. If your change touches a hot path in `py6502.sim`, re-read the
    performance rules in `src/py6502/sim/CLAUDE.md`. "No Python loops in
    steady state" is non-negotiable.
-3. Run the tests (once the v0.1 harness lands).
+3. Run `pytest`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with an integrated assembler, snippet editor, and sprite tools. See
 
 ## Status
 
-v0.1 is in active development. It ships a cycle-accurate 6502, the Apple I
+**v0.1** is feature-complete. It ships a cycle-accurate 6502, the Apple I
 preset (with bundled wozmon ROM and Sphere font), a system selector with
 preset / user-config / custom-system pickers, a debug panel with
 step-level debugging and a memory monitor, a runtime binary loader, and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -510,17 +510,26 @@ version:
 Detailed in the test plan (see
 [ROADMAP.md](ROADMAP.md)). The architectural summary:
 
+- **Unit tests** under `tests/` cover the `System` build pipeline end
+  to end: config loader (`test_system_loader.py`,
+  `test_system_smoke.py`), validation rules (`test_options.py`,
+  `test_binaries.py`), config writer round-trip (`test_writer.py`),
+  asset manifest (`test_manifest.py`), per-user config paths
+  (`test_paths.py`), runtime binary loading
+  (`test_runtime_load_binary.py`), Apple I region split
+  (`test_apple1_split.py`), and the strict-mode error paths for
+  invalid opcodes (`test_invalid_opcode.py`) and unmapped memory
+  (`test_unmapped_memory.py`).
 - **Klaus 6502 functional tests** and **Bruce Clark decimal tests**
-  are vendored as a git submodule and run as pytest fixtures.
-- The functional-test fixture builds a bare `System` with a single 64
-  KiB RAM region, loads the Klaus binary, sets `PC = 0x0400`, and calls
-  `system.run_cycles(96_247_419)`. Success is asserted by reading `$0200`.
-- A **performance regression test** (`tests/test_performance.py`) runs
-  the same fixture and asserts `cycles/sec > FLOOR_HZ`. This is the
-  canary for accidental Python-loop reintroduction.
-- **Unit tests** cover `BusController` (overlap detection, unmapped
-  access, refcounting) and the config loader (validation rules, source
-  URI resolution).
+  are deferred to v0.3 (see issue
+  [#50](https://github.com/ricky-groenewald/py6502/issues/50)). The
+  upstream binaries are GPL-3.0, so the v0.3 plan fetches them at CI
+  time rather than vendoring them in the wheel; thin runners under
+  `scripts/` will invoke them once that lands.
+- A **performance regression test** whose entire job is to fail loudly
+  if a Python loop sneaks back into the hot path is on the v0.1 punch
+  list and will land alongside the Klaus harness in v0.3 (it needs the
+  Klaus binary as its representative workload).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,9 +53,8 @@ wrong here, every later release pays for it.
 - GitHub Actions CI that builds the Cython extensions and runs the full
   pytest suite (with `@pytest.mark.slow` for the Klaus runs).
 - Fix undefined-behaviour on invalid opcodes / unmapped memory accesses.
-- Finalise the new `Py6502App` UI shell so it reaches feature parity with
-  the legacy `py6502ui.py` (disassembly panel, register view, memory monitor,
-  binary loader) — then retire the legacy module.
+- Finalise the `Py6502App` UI shell with disassembly panel, register
+  view, memory monitor, and binary loader.
 - Documentation: README + per-package READMEs, in-source comments on the 6502
   core.
 
@@ -63,7 +62,6 @@ wrong here, every later release pays for it.
 
 - [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
 - [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
-- [#51](https://github.com/ricky-groenewald/py6502/issues/51) — Binary source picker: filesystem vs bundled assets, backed by an asset manifest
 
 **Explicit non-goals for v0.1.**
 

--- a/docs/SYSTEM_CONFIG.md
+++ b/docs/SYSTEM_CONFIG.md
@@ -581,25 +581,32 @@ same reason.
 
 1. **Resolve the CPU.** `COMPONENT_REGISTRY[config.cpu.type]()`, store
    as `self._cpu`, stash `self._cpu_hz`.
-2. **Build buses.** For each entry in `config.buses`, create a
-   `BusController` and store it in `self._buses[name]`. Inject the CPU
-   into the `main` bus.
+2. **Build the main bus.** Create a `BusController("main", self._cpu, …)`
+   and store it in `self._buses["main"]`. (v0.1 ships single-bus; the
+   `_buses` dict is already in place for v0.2's multi-bus expansion.)
 3. **Wire memory regions.** For each `MemoryRegion`: create a `Memory`
-   component of the right size and read-only flag and call
+   component of the right size and `read_only` flag and call
    `self._buses[region.bus].add_component(mem, region.start)`. Regions
    are zero-initialised.
-4. **Wire peripherals.** Flatten `display` + `inputs` + `audio` +
-   `other` into one internal list. For each spec: resolve the type via
-   the registry, instantiate with `(bus_controller, **spec.params)`,
-   and call `self._buses[spec.bus].add_component(periph, spec.address)`.
-   Keep a **direct reference** to the `display` device in
-   `self._display` so `get_framebuffer()` never does a lookup.
-5. **Load binaries.** For each `BinarySource` in `config.binaries`,
+4. **Load binaries.** For each `BinarySource` in `config.binaries`,
    resolve the URI and walk the covering memory regions on the target
    bus (validated contiguous by Rule 13), writing each slice into the
    matching `Memory` component via `set_data` — this path bypasses the
-   runtime read-only guard so `read_only` regions can hold ROM data.
-6. **Reset.** Call `self._buses["main"].send_reset()`.
+   runtime read-only guard so `read_only` regions can hold ROM
+   payloads. Binaries are loaded **before** peripherals so a
+   peripheral's `bind()` can read freshly-loaded ROM bytes if it needs
+   to.
+5. **Wire peripherals.** For each `display`, `inputs`, `audio`, and
+   `other` spec: resolve the type via the registry, instantiate with
+   `cls(**spec.params)`, and call
+   `self._buses[spec.bus].add_component(periph, spec.address)`. Keep
+   direct references for `display` (one) and `inputs` (a list) so
+   `get_framebuffer()` and `send_key()` never do a lookup.
+6. **Late-bind.** Call `bind(self)` on the display and on every input
+   peripheral, so they can grab cross-component refs (e.g. read
+   `cpu_hz`) and subscribe to tick hooks now that every other
+   component is on the bus.
+7. **Reset.** Call `self._buses["main"].send_reset()`.
 
 ### Clocking
 

--- a/src/py6502/sim/CLAUDE.md
+++ b/src/py6502/sim/CLAUDE.md
@@ -119,8 +119,10 @@ DSP busy-timer.
 ### Accuracy First
 
 Hardware timing is a contract. `Apple1Display`'s DSP bit 7 stays busy
-for exactly one NTSC frame (`16667` cycles at 1 MHz) after a DSP write —
-not "some cycles", not "cleared at the next batch boundary". Test
+for exactly one NTSC frame (≈16,667 cycles at 1 MHz, computed at
+`bind()` time as `round(cpu_hz / 60)` so the timing scales with the
+configured clock — not hardcoded, not "some cycles", not "cleared at
+the next batch boundary"). Test
 `test_dsp_busy_timing_via_system_run_cycles` locks this at batch
 granularity so future refactors can't silently regress it. When you add
 a peripheral with hardware-observable timing, write the equivalent test

--- a/src/py6502/sim/README.md
+++ b/src/py6502/sim/README.md
@@ -2,8 +2,9 @@
 
 The Cython simulator half of `py6502`. Everything in this package is on
 the hot path: a cycle-accurate 6502 core, a flat 64K bus, pluggable
-addressable components, and (once v0.1 lands) a `System` façade that
-builds a whole machine from a declarative config file.
+addressable components, and a `System` façade that builds a whole
+machine from a declarative YAML config (see
+[`docs/SYSTEM_CONFIG.md`](../../../docs/SYSTEM_CONFIG.md)).
 
 For the full runtime model see [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md);
 for the config format see [`docs/SYSTEM_CONFIG.md`](../../../docs/SYSTEM_CONFIG.md);
@@ -14,11 +15,11 @@ for the rules Claude follows when editing this package see
 
 ```
 bus/          Component base class, BusController, Memory, EmptyAddress
-cpu/          MOS6502 (cycle-accurate)
+cpu/          MOS6502 (cycle-accurate, precomputed [256][2] dispatch)
 graphics/     TextDisplay + Font (character-grid renderer)
-peripherals/  Apple1; NES components land in v0.2
-system/       System façade — draft, intentionally not built yet
-assets/       Bundled BIOS ROMs, fonts
+peripherals/  Apple1Display, Apple1Keyboard
+system/       System façade, YAML loader, component registry, config dataclasses
+assets/       Bundled BIOS ROMs, fonts, preset YAML configs
 ```
 
 Each subpackage exposes its public API via its own `__init__.py` shim so

--- a/src/py6502/sim/bus/buscontroller.pyx
+++ b/src/py6502/sim/bus/buscontroller.pyx
@@ -1,7 +1,15 @@
 """
 CYTHON CONTROLLER COMPONENT CLASS IMPLEMENTATIONS
 
-Simulator definitions and functions for a component controller
+The BusController is the heart of the address-routing layer. It owns a
+flat 64K table of ``MappedAddress`` slots — one per 16-bit address —
+each holding a raw ``PyObject*`` to the owning Component plus the
+component-relative offset. A bus read/write is therefore one array
+indexed lookup, one C cast, and one cdef virtual call into the
+component — no Python attribute access, no list walk, no hash lookup.
+
+Tick-hook fan-out is intentionally batched, not per-cycle: see
+``run_cycles`` for the reasoning.
 """
 from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
 from cython cimport boundscheck, wraparound
@@ -22,10 +30,15 @@ class AddressRangeUnavailable(Exception):
 
 cdef class BusController(Component):
     """
-    Class definition for an 8-bit component controller
+    Class definition for an 8-bit component controller.
+
+    Holds the address→Component map and routes the CPU's reads/writes
+    through it. Also owns the tick-hook list, so peripherals can hang
+    cycle-accounting work off the end of every ``run_cycles`` batch
+    without poking at the CPU hot path.
     """
     def __init__(self, str controller_name, MOS6502 processor, bint raise_on_unmapped_access=True) -> None:
-        # Controllers will always only have 16-bit address space
+        # Controllers always have a 16-bit address space — 0x10000 slots.
         super().__init__(0x10000, controller_name)
         self._processor = processor
         self._processor.set_memory_bus(self)
@@ -33,12 +46,20 @@ cdef class BusController(Component):
         self._current_bus_data = 0
         self._current_bus_read_write_bar = 1
         self._tick_hooks = []
+        # Every unmapped slot points at a single shared EmptyAddress
+        # sentinel. We hand it a pointer to ``_current_bus_data`` so it
+        # can return the last byte that was on the bus (open-bus
+        # behaviour) when ``raise_on_unmapped_access`` is False.
         self._empty_address = EmptyAddress(
             'EmptyAddress',
             raise_on_unmapped_access
         )
         self._empty_address.set_bus_data_ptr(&self._current_bus_data)
 
+        # The MappedAddress table stores raw PyObject* pointers — Python's
+        # refcount machinery does not see them. We have to INCREF here for
+        # every cell, and the matching DECREF lives in __dealloc__ (and,
+        # per cell, in add_component when a real component takes over).
         for i in range(0x10000):
             self._component_address_map[i].component = <PyObject*>self._empty_address
             self._component_address_map[i].internal_address = i
@@ -77,12 +98,15 @@ cdef class BusController(Component):
                     f'Address overlap at 0x{address_start+i:04X} with {conflict_name}.'
                 )
 
-        # Then map the addresses
+        # Then map the addresses. Each cell's PyObject* slot is being
+        # repointed from the shared EmptyAddress sentinel to the real
+        # component, so refcount the swap by hand: INCREF the new owner,
+        # DECREF the EmptyAddress slot we're displacing.
         for i in range(component.get_size()):
             self._component_address_map[address_start+i].internal_address = i
             self._component_address_map[address_start+i].component = <PyObject*>component
             Py_INCREF(component)
-            Py_DECREF(self._empty_address) # NEED TO decrement ref count to empty address
+            Py_DECREF(self._empty_address)
 
     cdef void register_tick_hook(self, object component):
         """
@@ -99,6 +123,16 @@ cdef class BusController(Component):
     @boundscheck(False)
     @wraparound(False)
     cdef void run_cycles(self, unsigned long cycles) except *:
+        # The hot loop. ``_mos6502_step`` is a free cdef function — calling
+        # it directly skips the per-iteration vtable dispatch we'd pay
+        # going through ``processor.clock()``.
+        #
+        # Tick hooks fire **once per batch**, not once per cycle, with the
+        # batch size handed in. Peripherals that need cycle-accurate
+        # timing (e.g. Apple1Display's DSP busy timer) keep their own
+        # countdown and decrement by ``n`` in on_cycles_elapsed — that's
+        # how we keep the steady-state loop entirely inside compiled C
+        # while still giving the rest of the system a chance to breathe.
         cdef Py_ssize_t hook_idx
         cdef Py_ssize_t hook_count
         cdef MOS6502 processor = self._processor

--- a/src/py6502/sim/bus/emptyaddress.pyx
+++ b/src/py6502/sim/bus/emptyaddress.pyx
@@ -1,9 +1,22 @@
 """
-EmptyAddress: A dummy component for unmapped addresses.
+EmptyAddress: the sentinel component for unmapped bus addresses.
 
-This component implements dummy read and write operations.
-If 'raise_on_unmapped' is True, any read or write will raise an UnallocatedAddressError.
-Otherwise, the operations simply return 0.
+Real hardware doesn't have "unmapped" memory in the Python sense — it
+either floats the bus (open-bus behaviour: whatever was last driven on
+the data lines lingers there) or behaves in some platform-specific way.
+We model both modes:
+
+- ``raise_on_unmapped=True`` — strict mode. Every access raises
+  ``UnallocatedAddressError``. This is what tests and debug builds
+  want: no silent reads of garbage data.
+- ``raise_on_unmapped=False`` — open-bus mode. Reads return the last
+  byte the bus controller saw (via ``set_bus_data_ptr``), writes are
+  swallowed. This is the production setting for emulating machines
+  that genuinely tolerate unmapped accesses.
+
+The toggle lives on the BusController side and is flipped at runtime
+via ``set_unmapped_memory_mode`` — the user sees it in the Settings
+window as "Halt on unmapped memory".
 """
 
 from py6502.sim.bus.component cimport Component
@@ -11,22 +24,28 @@ from cython cimport boundscheck, wraparound
 
 class UnallocatedAddressError(Exception):
     """
-    Atempted to access an address not allocated to a component
+    Attempted to access an address not allocated to a component.
     """
 
 cdef class EmptyAddress(Component):
     def __init__(self, str name, bint raise_on_unmapped) -> None:
-        # The size is arbitrary because the internal address passed in is ignored.
+        # ``size=0`` because EmptyAddress never owns a region itself —
+        # it's only ever installed as the sentinel in slots that haven't
+        # been claimed by a real Component.
         super().__init__(0, name)
         self._raise_on_unmapped = raise_on_unmapped
         self._bus_data_ptr = NULL
 
     cdef void set_bus_data_ptr(self, unsigned char* ptr):
+        # The BusController hands us a pointer to its ``_current_bus_data``
+        # so open-bus reads can return the last byte that was driven.
         self._bus_data_ptr = ptr
 
     @boundscheck(False)
     @wraparound(False)
     cdef int read(self, unsigned short address) except -1:
+        # Strict mode raises; open-bus mode returns whatever's lingering
+        # on the bus (see module docstring).
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'
@@ -36,6 +55,8 @@ cdef class EmptyAddress(Component):
     @boundscheck(False)
     @wraparound(False)
     cdef int write(self, unsigned short address, unsigned char data) except -1:
+        # Strict mode raises; open-bus mode silently accepts the write
+        # (the byte goes nowhere — there's no memory here).
         if self._raise_on_unmapped:
             raise UnallocatedAddressError(
                 f'Address not allocated to a component: 0x{address:04X}'

--- a/src/py6502/sim/graphics/textdisplay.pxd
+++ b/src/py6502/sim/graphics/textdisplay.pxd
@@ -1,5 +1,5 @@
 from libc.stdio cimport *
-    
+
 cdef class Font:
     cdef bint* character_set
     cdef unsigned char width
@@ -10,6 +10,11 @@ cdef class Font:
     cdef inline bint get_character_pixel(self, unsigned char character, unsigned char x, unsigned char y)
 
 cdef class TextDisplay:
+    # See textdisplay.pyx for the field-by-field semantics; this header
+    # only declares the storage. The 240×256 buffer is fixed-size on
+    # purpose: it's contiguous, stack-shaped, and big enough for every
+    # v0.1 display we ship. NES-era resolutions in v0.2 will use a
+    # different graphics class entirely (this one is character-grid).
     cdef Font _font
     cdef unsigned int _resolution_x
     cdef unsigned int _resolution_y
@@ -19,14 +24,18 @@ cdef class TextDisplay:
     cdef unsigned char _cursor_pos_y
     cdef unsigned char _cursor_last_cr_y_pos
     cdef unsigned char _start_cursor_row
-    cdef unsigned char _cursor_mode  # 0 = off, 1 = blinking, 2 = solid
+    cdef unsigned char _cursor_mode
     cdef unsigned char _cursor_blink_timer
     cdef bint _cursor_visible
     cdef unsigned char* _cursor_pixel_map
-    cdef unsigned char[240][256] _screen_buffer # 240 rows, 256 columns
+    # _screen_buffer[y][x] — y is the row (0 = top of pixel space, not
+    # of the unwrapped logical screen), x is the column. Values are
+    # colour indices into _colors, not RGBA.
+    cdef unsigned char[240][256] _screen_buffer
     cdef unsigned char _character_max_cols
     cdef unsigned char _character_max_rows
-    cdef float[3][4] _colors #RGBA - 0 = background, 1 = foreground, 2 = cursor
+    # _colors[i] is RGBA. i=0 background, i=1 foreground, i=2 cursor.
+    cdef float[3][4] _colors
 
     cdef list get_screen_buffer(self)
     cdef void set_cursor(self, unsigned char character, float[4] color, unsigned char cursor_mode)

--- a/src/py6502/sim/graphics/textdisplay.pyx
+++ b/src/py6502/sim/graphics/textdisplay.pyx
@@ -1,7 +1,38 @@
+"""
+TextDisplay + Font: a character-grid renderer with a vintage-style
+blinking cursor and seamless scroll.
+
+The Font wraps a tiny custom binary format we use to pack pixel-perfect
+glyphs out of historical font ROMs. The TextDisplay treats its
+``_screen_buffer`` as a circular row buffer so a scroll-up is just an
+index rebase, not a memcpy.
+"""
 from libc.stdio cimport *
 from libc.stdlib cimport malloc, free
 
 cdef class Font:
+    """
+    Bitmap font, unpacked from a custom .bin format on construction.
+
+    File layout:
+
+        byte 0:    header
+                     bits 7..4 — glyph width  in pixels (1..15)
+                     bits 3..0 — glyph height in pixels (1..15)
+        byte 1..:  glyph rows, packed MSB-first.
+                   Each glyph occupies (height × ceil(width / 8)) bytes,
+                   so a typical 8x8 glyph is 8 bytes (one byte per row,
+                   one bit per pixel). Glyphs are stored in ASCII order
+                   starting from whatever the font ROM started at —
+                   character_set[N] is the Nth glyph in the file, the
+                   caller is responsible for any mapping (Apple 1's
+                   0x60..0x7F → 0x40..0x5F quirk lives in
+                   Apple1Display, not here).
+
+    The unpacked pixel grid is stored as a flat ``bint`` array indexed
+    by ``(char * height + y) * width + x`` so per-pixel lookup at draw
+    time is one multiply-add and one indirect load.
+    """
     def __init__(self, filename):
         self._create_character_set(filename.encode('utf-8'))
 
@@ -14,6 +45,8 @@ cdef class Font:
         if cfile == NULL:
             raise FileNotFoundError(f"File {filename} not found")
 
+        # Slurp the whole file. Fonts are tiny (the Apple 1 sphere font
+        # is ~520 bytes), so a one-shot read beats streaming.
         fseek(cfile, 0, SEEK_END)
         cdef size_t file_size = ftell(cfile)
         fseek(cfile, 0, SEEK_SET)
@@ -21,11 +54,17 @@ cdef class Font:
         fread(buffer, sizeof(unsigned char), file_size, cfile)
         fclose(cfile)
 
+        # Unpack the header. ``set_size`` is derived from the remaining
+        # bytes: each glyph takes height × ceil(width / 8) bytes.
         self.width = (buffer[0] & 0xF0) >> 4
         self.height = buffer[0] & 0x0F
         self.set_size = <unsigned char>((file_size - 1) / (self.height * ((self.width + 7) // 8)))
         self.character_set = <bint*>malloc(self.set_size * sizeof(bint) * self.width * self.height)
 
+        # Unpack each packed glyph row into individual bits. The shift
+        # ``width - col - 1`` walks pixels left-to-right because the
+        # source bytes are MSB-first — the leftmost pixel is the high
+        # bit of the row byte.
         cdef int offset
         for char_num in range(self.set_size):
             for row in range(self.height):
@@ -36,9 +75,33 @@ cdef class Font:
         free(buffer)
 
     cdef inline bint get_character_pixel(self, unsigned char character, unsigned char x, unsigned char y):
+        # Inlined into the renderer hot path: one indexed load per pixel.
         return self.character_set[(character * self.height + y) * self.width + x]
 
 cdef class TextDisplay:
+    """
+    Character-grid framebuffer with a circular row-buffer for free
+    scroll-up.
+
+    State invariants worth knowing before touching this:
+
+    - ``_screen_buffer[y][x]`` holds a *colour index* (0/1/2 — see
+      ``_colors``), not a packed RGBA value. The RGBA expansion only
+      happens in ``get_screen_buffer`` so we never carry around a 4×
+      buffer.
+    - ``_cursor_pos_(x|y)`` are *character* coordinates inside the
+      visible grid, **not** pixel coordinates.
+    - ``_start_cursor_row`` is the character-row index that the renderer
+      treats as the top of the screen. When CR scrolls past the bottom,
+      we just advance this index modulo ``_character_max_rows`` and
+      clear the freshly-exposed line — no copy. ``get_screen_buffer``
+      unwraps the rotation when it walks the buffer to RGBA.
+    - ``_cursor_mode``: 0 = off, 1 = blinking, 2 = solid. The blinking
+      timer cadence is 30 frames per phase (≈half a second at 60 FPS).
+    - ``_cursor_pixel_map`` is the *unpacked* glyph for the cursor
+      character, computed once in ``set_cursor`` so ``redraw_cursor``
+      doesn't re-walk the font on every frame.
+    """
     def __init__(self, resolution_x, resolution_y, padding_x, padding_y, Font font):
         # Basic screen setup
         self._resolution_x = resolution_x
@@ -46,6 +109,9 @@ cdef class TextDisplay:
         self._pixel_padding_x = padding_x
         self._pixel_padding_y = padding_y
         self._font = font
+        # _colors[0] = background, [1] = foreground, [2] = cursor.
+        # Defaults are black/white/white; peripherals override via
+        # set_background_color / set_foreground_color / set_cursor.
         self._colors[0] = [0.0, 0.0, 0.0, 1.0]
         self._colors[1] = [1.0, 1.0, 1.0, 1.0]
         self._colors[2] = [1.0, 1.0, 1.0, 1.0]
@@ -55,10 +121,12 @@ cdef class TextDisplay:
         self._cursor_pos_y = 0
         self._cursor_last_cr_y_pos = 0
         self._start_cursor_row = 0
-        self._cursor_mode = 1 # 0 = off, 1 = blinking, 2 = solid
+        self._cursor_mode = 1
         self._cursor_blink_timer = 0
         self._cursor_visible = True
         self._cursor_pixel_map = <unsigned char*>malloc(font.width * font.height * sizeof(unsigned char))
+        # Visible character-grid dimensions, with the padding stripped
+        # off both sides — this is the cursor's actual playing field.
         self._character_max_cols = (resolution_x - (padding_x * 2)) // font.width
         self._character_max_rows = (resolution_y - (padding_y * 2)) // font.height
 
@@ -69,6 +137,9 @@ cdef class TextDisplay:
             free(self._cursor_pixel_map)
 
     cdef list get_screen_buffer(self):
+        # Tick the cursor blink (frame-paced, not cycle-paced — a "frame"
+        # here is one call to this method, which the frontend invokes once
+        # per UI frame).
         if self._cursor_mode == 1:
             self._cursor_blink_timer += 1
             if self._cursor_blink_timer == 30:
@@ -77,32 +148,46 @@ cdef class TextDisplay:
 
         self.redraw_cursor()
 
+        # Flatten the buffer into a single RGBA-per-pixel list in screen
+        # order: top padding band, then the *unwrapped* content (the
+        # post-scroll rows that should appear at the top, then the
+        # pre-scroll rows that should appear below them), then bottom
+        # padding band. The two content slices together implement the
+        # circular-buffer rotation without ever moving any pixels.
         return (
-            [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Top padding
-            + [rgba_val for row in range(self._start_cursor_row * self._font.height + self._pixel_padding_y, self._resolution_y - self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # From content y-start to bottom padding
-            + [rgba_val for row in range(self._pixel_padding_y, self._start_cursor_row * self._font.height + self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # From top padding end to content y-start
-            + [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Bottom padding (Same as top padding)
+            [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Top padding band
+            + [rgba_val for row in range(self._start_cursor_row * self._font.height + self._pixel_padding_y, self._resolution_y - self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # Rows from the scroll origin down to the bottom of the content area
+            + [rgba_val for row in range(self._pixel_padding_y, self._start_cursor_row * self._font.height + self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # Rows from the top of the content area up to the scroll origin
+            + [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Bottom padding band (same colour as top)
         )
 
     cdef void backspace(self):
+        # Refuse to backspace past the start of the current input line
+        # (the column-0 cell of the row that received the last CR). On
+        # real Apple I hardware the backspace key is just an "underscore
+        # back into the current cell"; we take the same liberty.
         if self._cursor_pos_x == 0 and self._cursor_pos_y == self._cursor_last_cr_y_pos:
-            # Can't backspace CR
             return
 
         cdef int y_offset = self._pixel_padding_y + self._cursor_pos_y * self._font.height
         cdef int x_offset = self._pixel_padding_x + self._cursor_pos_x * self._font.width
 
+        # Wipe the cell the cursor is *currently* sitting in.
         for y in range(self._font.height):
             for x in range(self._font.width):
                 self._screen_buffer[y_offset + y][x_offset + x] = 0
-        
+
+        # Move the cursor one cell to the left, wrapping to the previous
+        # row if we were at column 0. The (max + y - 1) % max dance is
+        # just modular subtraction that's safe for unsigned types.
         if self._cursor_pos_x > 0:
             self._cursor_pos_x -= 1
         else:
             self._cursor_pos_x = self._character_max_cols - 1
             self._cursor_pos_y = (self._character_max_rows + self._cursor_pos_y - 1) % self._character_max_rows
 
-        # Draw cursor
+        # Reset the blink so the user can see exactly where the cursor
+        # landed. blink_timer=28 ≈ "don't blink for ~half a phase".
         if self._cursor_mode:
             self._cursor_blink_timer = 28
             self._cursor_visible = False
@@ -112,6 +197,10 @@ cdef class TextDisplay:
         cdef int x_offset = self._pixel_padding_x + self._cursor_pos_x * self._font.width
 
         if character == 0x0D: # CR
+            # CR's contract here: clear the cell the cursor is on (so the
+            # old cursor glyph doesn't linger on the previous line) and
+            # advance to column 0 of the next row. Apple 1 had no LF —
+            # CR did the work of both.
             for y in range(self._font.height):
                 for x in range(self._font.width):
                     self._screen_buffer[y_offset + y][x_offset + x] = 0
@@ -121,14 +210,22 @@ cdef class TextDisplay:
             self._cursor_last_cr_y_pos = self._cursor_pos_y
 
             if self._cursor_pos_y == self._start_cursor_row:
-                # If cursor is at the top of the screen, scroll and clear cursor line
+                # We've wrapped into the row that's currently the visible
+                # top — that's the scroll trigger. Bump _start_cursor_row
+                # forward (which logically pushes the entire visible area
+                # up by one row, see the docstring on the circular buffer)
+                # and then clear what is now the bottom-most row so it
+                # doesn't show stale content from before the scroll.
                 self._start_cursor_row = (self._start_cursor_row + 1) % self._character_max_rows
                 y_offset = self._pixel_padding_y + self._cursor_pos_y * self._font.height
                 for y in range(self._font.height):
                     for x in range(self._pixel_padding_x, self._resolution_x - self._pixel_padding_x):
                         self._screen_buffer[y_offset + y][x] = 0
 
-        else: # Any other character
+        else:
+            # Normal printable character: stamp the glyph into the
+            # current cell, advance the cursor, and scroll if we ran off
+            # the right edge into the row that's currently the top.
             for y in range(self._font.height):
                 for x in range(self._font.width):
                     self._screen_buffer[y_offset + y][x_offset + x] = self._font.get_character_pixel(character, x, y)
@@ -137,14 +234,14 @@ cdef class TextDisplay:
             if self._cursor_pos_x == 0:
                 self._cursor_pos_y = (self._cursor_pos_y + 1) % self._character_max_rows
                 if self._cursor_pos_y == self._start_cursor_row:
-                    # If cursor is at the top of the screen, scroll and clear cursor line
+                    # Same scroll path as the CR case above.
                     self._start_cursor_row = (self._start_cursor_row + 1) % self._character_max_rows
                     y_offset = self._pixel_padding_y + self._cursor_pos_y * self._font.height
                     for y in range(self._font.height):
                         for x in range(self._pixel_padding_x, self._resolution_x - self._pixel_padding_x):
                             self._screen_buffer[y_offset + y][x] = 0
 
-        # Draw cursor
+        # Reset the blink (same reasoning as backspace).
         if self._cursor_mode:
             self._cursor_blink_timer = 28
             self._cursor_visible = False

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -20,6 +20,20 @@ from py6502.sim.system.registry import resolve as _resolve_type
 
 
 cdef class System:
+    """
+    The Python-facing object that owns a whole machine.
+
+    ``System`` is the *only* surface the frontend is meant to touch. It
+    holds the CPU, the bus(es), and every live Component, built once
+    from a ``SystemConfig`` and then frozen. The frontend makes one
+    coarse call per UI frame (``run_for_microseconds`` / ``run_cycles``)
+    and reads back cheap snapshots (``get_framebuffer``,
+    ``get_registers``) — everything else happens behind the Cython wall.
+
+    See ``docs/ARCHITECTURE.md`` §3.6 for the runtime model and
+    ``docs/SYSTEM_CONFIG.md`` §10 for the build sequence this class
+    implements.
+    """
     def __init__(self, config, base_dir=None):
         cdef Component component
         cdef BusController main_bus
@@ -35,14 +49,21 @@ cdef class System:
         self._inputs = []
         self._display = None
 
-        # Resolve the CPU class via the registry, not a hardcoded import.
+        # Resolve the CPU class via the registry, not a hardcoded import:
+        # the config's ``cpu.type`` string is the source of truth, which
+        # keeps the door open for future cores (65C02 in v0.3, etc.).
         cpu_cls = _resolve_type(config.cpu.type)
         self._cpu = cpu_cls()
 
+        # v0.1 is single-bus. ``buses`` is already a dict so v0.2 can
+        # carry a CPU bus + PPU bus without changing this class's shape.
         main_bus = BusController("main", self._cpu, False)
         self._buses["main"] = main_bus
 
         # --- Memory regions ---------------------------------------------
+        # Walk the validated memory layout and wire every region onto
+        # its declared bus. ``base_dir`` anchors later ``file:`` URI
+        # resolution; default is CWD for programmatic callers.
         resolve_base = Path(base_dir) if base_dir is not None else Path.cwd()
         for region in config.memory:
             mem = Memory(region.size, region.name, region.read_only)
@@ -50,8 +71,12 @@ cdef class System:
             self._memory_regions[region.name] = mem
 
         # --- Binary sources ---------------------------------------------
-        # Rule 13 has already validated coverage; this loop can trust the
-        # config and just walk covering regions, slicing bytes into each.
+        # Rule 13 (binaries cover a contiguous mapped range with no
+        # gaps and no overlap — see docs/SYSTEM_CONFIG.md §8) has
+        # already been validated by the loader, so this loop can trust
+        # the config and just walk covering regions, slicing bytes
+        # into each. Memory.set_data bypasses the read_only guard on
+        # purpose: ROM *payloads* are precisely what we're loading.
         for bs in config.binaries:
             data = resolve_source(bs.source, resolve_base)
             cursor = bs.address
@@ -91,9 +116,13 @@ cdef class System:
             component = self._instantiate_component(spec)
             self._wire_component(component, spec.address, spec.bus)
 
-        # Late-binding: every component gets a chance to grab cross-
-        # component refs or subscribe to tick hooks now that every other
-        # component has been added to the bus.
+        # Late-binding: every display/input component gets a chance to
+        # grab cross-component refs or subscribe to tick hooks now that
+        # every other component has been added to the bus. Doing this
+        # in a separate pass lets a component's ``bind()`` look up any
+        # peer without worrying about initialisation order (see
+        # Apple1Display.bind for a typical use — reading cpu_hz and
+        # registering the batch-end tick hook).
         if self._display is not None:
             (<Component>self._display).bind(self)
         for input_component in self._inputs:
@@ -113,18 +142,35 @@ cdef class System:
         return self._cpu_hz
 
     cpdef void run_cycles(self, unsigned long cycles) except *:
+        """Run exactly ``cycles`` CPU cycles. The hot path for the UI."""
         if cycles:
             (<BusController>self._buses["main"]).run_cycles(cycles)
 
     cpdef void run_for_microseconds(self, unsigned long microseconds) except *:
+        """
+        Run for the wall-clock elapsed time the frontend observed this
+        frame. Converted to cycles against the configured ``cpu_hz`` so
+        the effective frequency stays locked regardless of UI refresh
+        rate.
+        """
         if microseconds:
             (<BusController>self._buses["main"]).run_for_microseconds(microseconds, self._cpu_hz)
 
     cpdef unsigned long step_cycle(self) except *:
+        """Advance one CPU cycle. Used by the debug panel's Cycle button."""
         (<BusController>self._buses["main"]).run_cycles(1)
         return 1
 
     cpdef unsigned long step_instruction(self) except *:
+        """
+        Advance until the next instruction boundary. The CPU core
+        latches ``OPCODE`` / ``OPCODE_ADDR`` at the start of each
+        instruction, so "the boundary" is "the first cycle where at
+        least one of those two registers changes". The 16-cycle cap is
+        a safety net: the longest legal 6502 instruction takes 7 cycles
+        (RTI + page-cross variants), so anything past 16 means we've
+        somehow lost the marker and should bail rather than spin.
+        """
         cdef BusController bus = <BusController>self._buses["main"]
         cdef Registers start = bus.get_registers()
         cdef unsigned short start_addr = start.OPCODE_ADDR
@@ -142,16 +188,24 @@ cdef class System:
         return cycles
 
     cpdef void reset(self):
+        """Reset the CPU. Peripherals see no reset signal of their own."""
         (<BusController>self._buses["main"]).send_reset()
 
     cpdef void load_binary_at(self, unsigned int address, bytes data):
-        # Runtime counterpart to config-time binary loading. validate_coverage
-        # runs the same Rule-13-shape checks (zero bytes, address inside a
-        # region, contiguous, doesn't run off the end) and returns the
-        # covering regions; the write loop mirrors __init__'s behaviour.
-        # Like config-time loads, this writes through Memory.set_data, which
-        # bypasses the read_only flag — loading a ROM image at runtime is
-        # intentional, not a bug.
+        """
+        Runtime counterpart to config-time binary loading. Writes ``data``
+        onto the main bus starting at ``address``, walking across
+        contiguous memory regions exactly like ``__init__`` does.
+
+        ``validate_coverage`` runs the same Rule 13-shape checks the
+        loader applies to config-time binaries (non-empty, address lies
+        inside a region, regions are contiguous, payload doesn't run off
+        the end) and returns the covering regions for the write loop.
+
+        Like config-time loads, this writes through ``Memory.set_data``
+        which bypasses the ``read_only`` flag — loading a ROM image at
+        runtime is intentional, not a bug.
+        """
         cdef unsigned int cursor, local, take, offset, remaining
         if address > 0xFFFF:
             raise ConfigError(
@@ -180,35 +234,59 @@ cdef class System:
                 break
 
     cpdef Registers get_registers(self):
+        """Cheap snapshot of the CPU register file. Safe per frame."""
         return (<BusController>self._buses["main"]).get_registers()
 
     cpdef void set_registers(self, Registers registers):
         (<BusController>self._buses["main"]).set_registers(registers)
 
     cpdef object get_framebuffer(self):
+        """
+        Return the display's RGBA buffer (or None if there's no display).
+        The buffer is owned by the display peripheral and mutated in
+        place — the frontend reads from it directly, never copies it
+        per frame.
+        """
         if self._display is None:
             return None
         return (<Component>self._display).get_framebuffer()
 
     cpdef void register_tick_hook(self, object component):
+        """
+        Subscribe a component to the batch-end tick hook. Called from
+        a peripheral's ``bind()`` to receive ``on_cycles_elapsed(n)``
+        once at the end of every ``run_cycles`` batch.
+        """
         (<BusController>self._buses["main"]).register_tick_hook(component)
 
     cpdef unsigned char peek(self, unsigned short address):
+        """Debug read. Goes through the bus but is not cycle-accurate."""
         return (<BusController>self._buses["main"]).read(address)
 
     cpdef unsigned char poke(self, unsigned short address, unsigned char data):
+        """Debug write. Same caveat as ``peek``."""
         return (<BusController>self._buses["main"]).write(address, data)
 
     cpdef bint is_mapped(self, unsigned short address):
+        """True iff ``address`` is owned by a real Component (not the EmptyAddress sentinel)."""
         return (<BusController>self._buses["main"]).is_mapped(address)
 
     cpdef void set_invalid_opcode_mode(self, unsigned char mode):
+        # 0 = treat invalid opcodes as NOPs; 1 = raise InvalidOPCode.
+        # Toggled from the Settings window.
         self._cpu.set_invalid_opcode_mode(mode)
 
     cpdef void set_unmapped_memory_mode(self, bint crash):
+        # crash=True: unmapped accesses raise UnallocatedAddressError.
+        # crash=False: open-bus behaviour (last data byte lingers).
         (<BusController>self._buses["main"]).set_unmapped_memory_mode(crash)
 
     cpdef bint send_key(self, unsigned char char_):
+        """
+        Push one keystroke into the first input peripheral. Returns
+        False if its buffer is full so the frontend can hold the key
+        and try again next frame.
+        """
         if not self._inputs:
             return False
         return (<Component>self._inputs[0]).send_input(char_)
@@ -221,6 +299,11 @@ cdef class System:
     # Private helpers
     # ------------------------------------------------------------------
     cdef Component _instantiate_component(self, object spec):
+        # Resolve the component's class via the registry (same string
+        # → class mapping the loader uses) and call it with the spec's
+        # ``params`` dict. A bad ``type`` field yields KeyError from the
+        # registry; bad params yield TypeError from the constructor —
+        # both surface as ConfigError so the caller has one thing to catch.
         cls = _resolve_type(spec.type)
         try:
             instance = cls(**spec.params)
@@ -235,10 +318,10 @@ cdef class System:
         return <Component>instance
 
     cdef void _wire_component(self, Component component, unsigned int address, str bus_name):
-        # Single-point-of-truth for bus wiring. Today this is a direct
-        # add_component call; when non-contiguous address ranges are
-        # added (see ComponentSpec docstring), the extension lives
-        # here.
+        # Single point of truth for bus wiring. Today this is a direct
+        # add_component call; when non-contiguous address ranges arrive
+        # (see ComponentSpec docstring in config.py for the NES PPU
+        # mirror example), the multi-range fan-out lives here.
         if bus_name not in self._buses:
             raise ConfigError(f"Component references unknown bus {bus_name!r}")
         (<BusController>self._buses[bus_name]).add_component(component, address)

--- a/src/py6502/ui/README.md
+++ b/src/py6502/ui/README.md
@@ -40,10 +40,13 @@ themes.py        ThemeManager — DearPyGui theme factories
 
 ```python
 while dpg.is_dearpygui_running():
+    now = perf_counter()
+    dt = min(now - last_tick_time, MAX_CATCH_UP_SECONDS)
+    last_tick_time = now
     if self.system is not None:
         if self._sim_running:
             self._drain_keys_into_system()
-            self.system.run_for_microseconds(FRAME_MICROSECONDS)
+            self.system.run_for_microseconds(int(dt * 1_000_000))
             self._video.update_framebuffer(self.system.get_framebuffer())
         self._debug.refresh(self.system)
     dpg.render_dearpygui_frame()
@@ -52,6 +55,13 @@ while dpg.is_dearpygui_running():
 This is the one invariant the frontend has to protect: **one coarse call
 to the sim per UI frame**. Anything that loops over CPU cycles from here
 is a bug, regardless of whether the tests pass.
+
+The sim is paced by wall-clock `dt`, not a fixed per-frame constant, so
+its effective frequency stays locked to the configured `cpu_hz`
+regardless of the host display's refresh rate.
+`MAX_CATCH_UP_SECONDS` (50 ms) caps the dt the sim can be asked to
+advance in a single frame, which prevents catch-up bursts after a long
+pause.
 
 ## New System flow
 

--- a/src/py6502/ui/app.py
+++ b/src/py6502/ui/app.py
@@ -25,6 +25,11 @@ from py6502.ui.windows.systemselector import SystemSelectorWindow
 from py6502.ui.windows.video import VideoWindow
 
 
+# Cap on the dt the sim can be asked to advance in a single frame.
+# A long pause (modal dialog, OS hiccup, sleeping laptop) would
+# otherwise translate into a massive catch-up burst and visible stutter.
+# 50 ms ≈ 50,000 cycles at 1 MHz, which is still inside one frame's
+# wall-clock budget at 60 FPS.
 MAX_CATCH_UP_SECONDS = 0.05
 
 
@@ -52,6 +57,8 @@ class Py6502App:
         self._system_name: str = ""
         self.settings: AppSettings = load_settings()
         self._key_buffer: list[int] = []
+        # Pause/error gate for the per-frame loop. Cleared by Pause and
+        # by sim errors; set by Play and by a successful system load.
         self._sim_running = False
         self._sim_error: str | None = None
 
@@ -164,12 +171,21 @@ class Py6502App:
     # Per-frame loop
     # ------------------------------------------------------------------
     def run(self) -> None:
+        # The whole frontend lives inside this loop. Per the
+        # one-coarse-call-per-frame contract (see ui/CLAUDE.md), each
+        # iteration calls ``System.run_for_microseconds`` exactly once —
+        # the sim does the rest in compiled Cython.
         frame_count = 0
-        cycles_accum = 0  # cycles *issued* to the sim — never CPU-bound in v0.1, so ≈ delivered
+        # Cycles *issued* to the sim, not measured back from it. Used
+        # purely for the FPS / Hz readout in the viewport title; the sim
+        # is not CPU-bound at v0.1 cpu_hz so issued ≈ delivered.
+        cycles_accum = 0
         last_tick_time = perf_counter()
         fps_timer = last_tick_time
         while dpg.is_dearpygui_running():
             now = perf_counter()
+            # Wall-clock dt drives the sim, with MAX_CATCH_UP_SECONDS as
+            # the safety cap (see the constant's comment for why).
             dt = min(now - last_tick_time, MAX_CATCH_UP_SECONDS)
             last_tick_time = now
             if self.system is not None:
@@ -179,15 +195,21 @@ class Py6502App:
                     try:
                         self.system.run_for_microseconds(micros)
                     except (InvalidOPCode, UnallocatedAddressError) as exc:
+                        # _on_sim_error flips _sim_running off, so we
+                        # won't re-enter this branch until the user
+                        # acknowledges via Reset/Play.
                         self._on_sim_error(exc)
                     else:
                         cycles_accum += (micros * self.system.cpu_hz) // 1_000_000
                     self._video.update_framebuffer(self.system.get_framebuffer())
+                # Refresh the debug panel even when paused so single-step
+                # buttons reflect the current sim state immediately.
                 self._debug.refresh(self.system)
             dpg.render_dearpygui_frame()
             frame_count += 1
             elapsed = now - fps_timer
             if elapsed >= 2.0:
+                # Throttled viewport-title update (every ~2 s).
                 fps = frame_count / elapsed
                 avg_hz = cycles_accum / elapsed
                 suffix = f" - {self._system_name}" if self._system_name else ""
@@ -207,6 +229,9 @@ class Py6502App:
                 break
 
     def _on_sim_error(self, exc: Exception) -> None:
+        # Hard-stop the sim. Stays stopped until Reset (which clears the
+        # error and re-enables Play); plain Play won't recover, since
+        # the failing instruction is still where PC points.
         self._sim_running = False
         self._sim_error = str(exc)
         self._debug.on_sim_state_changed(running=False, error=str(exc))

--- a/src/py6502/ui/utils/instructionmaps.py
+++ b/src/py6502/ui/utils/instructionmaps.py
@@ -1,3 +1,17 @@
+"""6502 mnemonic → opcode-per-addressing-mode lookup table.
+
+This is the source-of-truth for opcode disassembly in the debug panel.
+``windows/debug.py`` flips it into an opcode → "MNEMONIC mode" dict at
+build time via ``_build_opcode_disasm`` so every refresh of the
+register panel is a single dict lookup.
+
+Column order (matches ADDRESSING_MODES in windows/debug.py):
+    immediate, absolute, zero-page, accumulator, implied,
+    (indirect,X), (indirect),Y, zero-page,X, absolute,X, absolute,Y,
+    relative, (indirect), zero-page,Y.
+
+``None`` means "this mnemonic has no encoding in that addressing mode".
+"""
 INSTRUCTION_MAP_6502 = {
 #MNEMONIC: [ #  ,   a  ,   zp ,   Acc,   Imp, ($,X), ($),Y,  zp,X,   a,X,   a,Y,   r  ,   ($),  zp,Y]
     'ADC': [0x69,  0x6D,  0x65,  None,  None,  0x61,  0x71,  0x75,  0x7D,  0x79,  None,  None,  None],
@@ -10,8 +24,9 @@ INSTRUCTION_MAP_6502 = {
     'BMI': [None,  None,  None,  None,  None,  None,  None,  None,  None,  None,  0x30,  None,  None],
     'BNE': [None,  None,  None,  None,  None,  None,  None,  None,  None,  None,  0xD0,  None,  None],
     'BPL': [None,  None,  None,  None,  None,  None,  None,  None,  None,  None,  0x10,  None,  None],
-    # BRK is always a 2-byte instruction, but the user does not need to specify an operand.
-    # However we will make provision for it having either an immediate value or no operand at all.
+    # BRK is always 2 bytes on the wire, but the operand byte is
+    # ignored — list it under both "immediate" and "implied" so the
+    # disassembler can render either spelling without lying.
     'BRK': [0x00,  None,  None,  None,  0x00,  None,  None,  None,  None,  None,  None,  None,  None],
     'BVC': [None,  None,  None,  None,  None,  None,  None,  None,  None,  None,  0x50,  None,  None],
     'BVS': [None,  None,  None,  None,  None,  None,  None,  None,  None,  None,  0x70,  None,  None],

--- a/src/py6502/ui/utils/keyhandler.py
+++ b/src/py6502/ui/utils/keyhandler.py
@@ -46,7 +46,15 @@ class KeyHandler:
 
 def _key_to_char(app_data: int, shift_down: bool) -> str | None:
     """Translate a DearPyGui key code into Apple I ASCII. Returns None for
-    keys that have no mapping."""
+    keys that have no mapping.
+
+    The bare integer constants (601, 596, 602, 606) are platform key
+    codes for ``;`` ``'`` ``=`` ``\\``` respectively that DearPyGui
+    surfaces in callbacks but does not expose as named ``mvKey_*``
+    enums. They were determined empirically by printing app_data on a
+    macOS host; if a future DearPyGui release adds named constants,
+    swap them in.
+    """
     if dpg.mvKey_A <= app_data <= dpg.mvKey_Z:
         return chr(app_data - dpg.mvKey_A + ord("A"))
     if dpg.mvKey_0 <= app_data <= dpg.mvKey_9:
@@ -61,9 +69,9 @@ def _key_to_char(app_data: int, shift_down: bool) -> str | None:
         return ">" if shift_down else "."
     if app_data == dpg.mvKey_Slash:
         return "?" if shift_down else "/"
-    if app_data == 601:
+    if app_data == 601:  # ; / :
         return ":" if shift_down else ";"
-    if app_data == 596:
+    if app_data == 596:  # ' / "
         return '"' if shift_down else "'"
     if app_data == dpg.mvKey_Open_Brace:
         return "{" if shift_down else "["
@@ -73,8 +81,8 @@ def _key_to_char(app_data: int, shift_down: bool) -> str | None:
         return "|" if shift_down else "\\"
     if app_data == dpg.mvKey_Minus:
         return "_" if shift_down else "-"
-    if app_data == 602:
+    if app_data == 602:  # = / +
         return "+" if shift_down else "="
-    if app_data == 606:
+    if app_data == 606:  # ` / ~
         return "~" if shift_down else "`"
     return None

--- a/src/py6502/ui/windows/debug.py
+++ b/src/py6502/ui/windows/debug.py
@@ -54,6 +54,9 @@ MEM_MONITOR_TAG = "MemMonitor"
 
 
 def _build_opcode_disasm() -> dict[int, str]:
+    # Inverts INSTRUCTION_MAP_6502 (mnemonic → [opcode per addressing
+    # mode]) into a flat opcode → "MNEMONIC mode" lookup. Cheaper than
+    # scanning the source map on every register-panel refresh.
     disasm: dict[int, str] = {}
     for mnemonic, encodings in INSTRUCTION_MAP_6502.items():
         for i, opcode in enumerate(encodings):
@@ -211,6 +214,11 @@ class DebugWindow:
         dpg.set_value(REG_OPCODE_DISASM_TAG, self._opcode_disasm.get(opcode, "???"))
 
     def _update_memory_monitor(self, system: System) -> None:
+        # 256-byte page hex/ASCII dump. Uses System.peek (debug-only,
+        # not cycle-accurate) so the dump is allowed even when the sim
+        # is paused. is_mapped guards against scrolling into an
+        # unmapped page when "Halt on unmapped memory" would otherwise
+        # raise from peek().
         page = self._mem_monitor_page
         base = page << 8
         lines: list[str] = []

--- a/src/py6502/ui/windows/systemselector.py
+++ b/src/py6502/ui/windows/systemselector.py
@@ -392,6 +392,9 @@ class SystemSelectorWindow:
             if meta["tags"]:
                 tags_str = ", ".join(str(t) for t in meta["tags"])
                 dpg.add_text(f"Tags: {tags_str}", parent=INFO_PANE_TAG, color=(180, 180, 180))
+            # Presets carry no resolved ``config`` object — they're only
+            # the metadata header. User configs do, because the loader
+            # has already parsed them into a SystemConfig.
             if not meta.get("is_preset", False):
                 self._render_file_line(path)
                 config = meta.get("config")
@@ -448,9 +451,12 @@ class SystemSelectorWindow:
         dpg.add_spacer(parent=INFO_PANE_TAG, height=12)
         dpg.add_text("Options", parent=INFO_PANE_TAG, color=(255, 255, 0))
         dpg.add_separator(parent=INFO_PANE_TAG)
+        # First time we render this preset's options in the current
+        # selector session, seed from whatever the user picked last
+        # time (persisted in settings.last_option_values keyed by path).
+        # Subsequent re-selects in the same session keep the in-memory
+        # picks so the user can toggle previews without losing state.
         if path not in self._option_values:
-            # Seed from last-used values for this path (from persisted settings),
-            # so the widgets reflect what the user picked last time.
             persisted = self._app.settings.last_option_values.get(path, {})
             self._option_values[path] = dict(persisted)
         selections = self._option_values[path]
@@ -598,8 +604,14 @@ class SystemSelectorWindow:
             binaries=binaries,
         )
 
-        # Validate via the loader before writing to disk — exercises
-        # Rule 13 binary coverage, which System.__init__ does not re-run.
+        # Round-trip the in-memory config through the loader before
+        # writing to disk. This is the only path that runs Rule 13
+        # (binary sources cover a contiguous mapped range with no gaps
+        # or overlap — see docs/SYSTEM_CONFIG.md §8); System.__init__
+        # trusts that the loader already enforced it. Catching the
+        # ConfigError here means the user sees the validation message
+        # in the form's status line instead of a cryptic load failure
+        # the next time they pick this preset.
         target_dir = paths.user_configs_dir()
         try:
             from_yaml_text(to_yaml_text(config), base_dir=target_dir)


### PR DESCRIPTION
## Summary
- Bring every `src/py6502/sim/` `.pyx` / `.pxd` up to the educational, personal voice that `cpu/mos6502.pyx` sets — touch-ups to `bus/buscontroller`, `bus/emptyaddress`, `system/system`, and a substantial commenting pass on `graphics/textdisplay`.
- Pass `src/py6502/ui/` for functional comments where the *why* wasn't obvious — `app.py` (frame loop, error gate), `windows/debug.py` (memory monitor), `windows/systemselector.py` (option seeding, Rule 13 round-trip), `utils/keyhandler.py` (hardcoded DPG key codes), `utils/instructionmaps.py`.
- Refresh root `README.md` (drop "once the v0.1 harness lands", tighten the DearPyGui custom-build note), `src/py6502/sim/README.md` (drop "draft, intentionally not built yet"), and `src/py6502/ui/README.md` (replace the stale `FRAME_MICROSECONDS` snippet with the wall-clock `dt` shape).
- Sweep doc drift: drop dead `py6502ui.py` references from root `CLAUDE.md`, `docs/ROADMAP.md`, and the `new-peripheral` skill; rewrite `docs/ARCHITECTURE.md` §8 to describe the tests that actually ship and move Klaus / Bruce into v0.3 framing; correct `docs/SYSTEM_CONFIG.md` §10 build-order; clarify the `Apple1Display` busy-timer wording in `src/py6502/sim/CLAUDE.md` to reflect #55.

## Why
v0.1 has only two open issues left and both are documentation: #3 (better code comments on the 6502 / sim) and #7 (READMEs for sim). Bundling them with the doc drift uncovered along the way closes the milestone in one coherent ship-quality docs PR rather than dragging it across three or four near-identical follow-ups, and avoids the situation where the next contributor reads `CLAUDE.md` and chases a dead `py6502ui.py` reference. No runtime code changes — comments and documentation only.

## Test plan
- [x] `pip install -e .` rebuilds Cython extensions cleanly.
- [x] `pytest` — 76 / 76 pass.
- [x] `python -m py6502` boots, Apple I preset comes up cleanly with no log output.
- [x] `grep -rn 'py6502ui' .` returns nothing in tracked files.

## Closes
Closes #3
Closes #7