### PR TITLE
Bind DPG raw texture to sim-owned RGBA framebuffer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,8 @@ cdef class Component:
     cdef inline str get_name(self): ...
 
     # Optional overrides for display / input devices
-    cdef list get_framebuffer(self): ...    # default: None
+    cdef object get_framebuffer(self): ...  # default: None (pure getter)
+    cdef void render_framebuffer(self): ... # default: no-op (per-frame refresh)
     cdef bint send_input(self, unsigned char char_): ...  # default: False
     cdef void clear_input(self): ...        # default: no-op
 ```
@@ -247,9 +248,15 @@ This design has two upsides:
   `unsigned char[::1]` memoryview. `read_only` regions silently drop
   writes (matching real hardware ROM behavior).
 - **`TextDisplay`** owns a character-grid framebuffer and a `Font`. It
-  exposes `place_character(ch)`, `backspace()`, `clear_screen()`, and
-  returns an RGBA list from `get_screen_buffer()`. Peripherals that
-  drive a text display (e.g. Apple I) embed one of these.
+  exposes `place_character(ch)`, `backspace()`, `clear_screen()`,
+  `render_framebuffer()` (invoked once per UI frame by
+  `System.sync_display` — flattens the index buffer + stamps the
+  cursor), and `get_screen_buffer()` (a pure reference getter that
+  returns the preallocated RGBA `array.array('f')` the sim owns). The
+  frontend binds a DearPyGui raw texture to that buffer once at
+  system-load time; per-frame GPU uploads are automatic and cost no
+  Python-level copies. Peripherals that drive a text display (e.g.
+  Apple I) embed one of these.
 - **`Font`** loads a custom binary font format described in
   `graphics/textdisplay.pyx`. The format will be revisited alongside
   the font-maker tool in v0.3 (see [ROADMAP.md](ROADMAP.md)).
@@ -266,9 +273,17 @@ Peripherals follow a small contract:
 
 - **Must** override `cdef read(addr)` and `cdef write(addr, data)` for
   their register file.
-- **May** override `cdef list get_framebuffer(self)` (defined on
-  `Component`) returning an RGBA buffer if they are a display device.
-  `System.get_framebuffer()` calls through the base-class vtable.
+- **May** override `cdef object get_framebuffer(self)` (defined on
+  `Component`) returning a preallocated RGBA float buffer if they are
+  a display device. `System.get_framebuffer()` calls through the
+  base-class vtable. The returned buffer is owned by the peripheral
+  and reused every frame — never allocate a fresh one per call. The
+  per-frame refresh into that buffer happens in a sibling override,
+  `cdef void render_framebuffer(self)`, which `System.sync_display`
+  invokes at the end of every coarse frontend call. Splitting the two
+  keeps `get_framebuffer` cheap (a pointer return) so the frontend
+  can bind its DPG raw texture to the result once and forget about
+  it.
 - **May** override `cdef bint send_input(self, unsigned char)` and
   `cdef void clear_input(self)` for keyboard-like devices.
   `System.send_key()` / `System.clear_input_buffer()` call through the
@@ -313,6 +328,7 @@ cpdef void load_binary_at(self, unsigned int address, bytes data)
 cpdef Registers get_registers(self)
 cpdef void set_registers(self, Registers registers)
 cpdef object get_framebuffer(self)
+cpdef void sync_display(self)
 cpdef void register_tick_hook(self, object component)
 cpdef unsigned char peek(self, unsigned short address)
 cpdef unsigned char poke(self, unsigned short address, unsigned char data)
@@ -329,6 +345,14 @@ called on the continuous-run hot path. `step_cycle` delegates to
 checking `get_registers()` between calls until the CPU loads a new
 opcode (OPCODE_ADDR or OPCODE changes). Both return the number of
 cycles consumed.
+
+`sync_display` is the one-per-UI-frame chokepoint for the RGBA
+flatten. `run_for_microseconds` / `step_cycle` / `step_instruction`
+all call it on the way out so the frontend never has to; it's public
+only so tests (and the initial-paint on system load) can force a
+render without advancing cycles. The low-level `run_cycles` primitive
+skips the sync on purpose — it runs inside `step_instruction`'s inner
+loop and repeating the flatten there would be pure waste.
 
 `peek`/`poke` forward to the `main` bus and exist for tests + debug
 panels. The CPU hot path still calls the `cdef read`/`write` directly
@@ -446,21 +470,23 @@ Py6502App.run() — DearPyGui frame loop
        │
        ├── system.run_for_microseconds(16667)
        │       │
-       │       ▼
-       │   BusController.run_cycles(16667)
+       │       ├── BusController.run_cycles(16667)
+       │       │       │
+       │       │       ▼
+       │       │   for _ in 16667: MOS6502.clock()
+       │       │       │
+       │       │       ▼
+       │       │   each clock reads/writes bus → component.read/write (cdef)
        │       │
-       │       ▼
-       │   for _ in 16667: MOS6502.clock()
-       │       │
-       │       ▼
-       │   each clock reads/writes bus → component.read/write (cdef)
+       │       └── sync_display()  → display.render_framebuffer()
+       │               (cursor blink + index→RGBA flatten into the
+       │                raw-texture-bound buffer)
        │
-       ├── framebuffer = system.get_framebuffer()
-       │
-       └── dpg.set_value("output_texture", framebuffer)
+       └── (the framebuffer is already up to date; no Python-level
+            upload needed here — the DPG raw texture is bound to it)
        │
        ▼
-  dpg.render_dearpygui_frame()
+  dpg.render_dearpygui_frame()   # DPG re-uploads the bound buffer to the GPU
 ```
 
 ### 6.3 Read cycle inside the CPU

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,8 +60,7 @@ wrong here, every later release pays for it.
 
 **Open issues in GitHub milestone "v0.1 Release - First 6502 release":**
 
-- [#3](https://github.com/ricky-groenewald/py6502/issues/3) — 6502: Better code comments
-- [#7](https://github.com/ricky-groenewald/py6502/issues/7) — Add README files to SIM
+_None — milestone closed._
 
 **Explicit non-goals for v0.1.**
 
@@ -132,6 +131,21 @@ divider-aware before it's useful.
 - [#32](https://github.com/ricky-groenewald/py6502/issues/32) — Multiprocessing sim/frontend split
 - [#33](https://github.com/ricky-groenewald/py6502/issues/33) — Frontend library re-evaluation (DearPyGui friction)
 - [#40](https://github.com/ricky-groenewald/py6502/issues/40) — Create Input / Display abstracts
+- [#50](https://github.com/ricky-groenewald/py6502/issues/50) — Wire Klaus + Bruce Clark tests into pytest with perf reporting
+- [#62](https://github.com/ricky-groenewald/py6502/issues/62) — [BUG] BusController corrupts bus snapshot on debug peek — add peek/poke bypass
+- [#63](https://github.com/ricky-groenewald/py6502/issues/63) — Gate debug-monitor refresh to pause/step events
+- [#64](https://github.com/ricky-groenewald/py6502/issues/64) — v0.2 dedup + dead-code + doc-drift cleanup pass
+- [#65](https://github.com/ricky-groenewald/py6502/issues/65) — v0.2 performance audit + baseline
+- [#66](https://github.com/ricky-groenewald/py6502/issues/66) — R2A03 CPU variant (no-BCD + OAM/DMC DMA stall)
+- [#67](https://github.com/ricky-groenewald/py6502/issues/67) — NMI / IRQ wiring for NES peripherals
+- [#68](https://github.com/ricky-groenewald/py6502/issues/68) — PPU bus: VRAM, nametable mirroring, palette RAM
+- [#69](https://github.com/ricky-groenewald/py6502/issues/69) — PixelDisplay graphics primitive (bitmap framebuffer)
+- [#70](https://github.com/ricky-groenewald/py6502/issues/70) — PPU register window on main bus ($2000-$3FFF + $4014)
+- [#71](https://github.com/ricky-groenewald/py6502/issues/71) — Mapper component contract (runtime bank-switching shape)
+- [#72](https://github.com/ricky-groenewald/py6502/issues/72) — Bundled NES preset(s) + asset manifest entry
+- [#73](https://github.com/ricky-groenewald/py6502/issues/73) — nestest CPU conformance runner in CI
+- [#74](https://github.com/ricky-groenewald/py6502/issues/74) — PAL NES sim-side support
+- [#75](https://github.com/ricky-groenewald/py6502/issues/75) — Save states (snapshot + restore emulator state)
 
 #2 and #4 are "v0.1 foundation" issues that live in the v0.2 milestone only
 because pytest/CI work will grow substantially as NES features land. The
@@ -173,7 +187,6 @@ fixture scaffolding itself ships in v0.1; v0.2 expands it.
 - [#21](https://github.com/ricky-groenewald/py6502/issues/21) — Customize and package dearpygui/imgui
 - [#24](https://github.com/ricky-groenewald/py6502/issues/24) — Enable saving of code snippets
 - [#26](https://github.com/ricky-groenewald/py6502/issues/26) — Character Map / Sprite Editors
-- [#50](https://github.com/ricky-groenewald/py6502/issues/50) — Wire Klaus + Bruce Clark tests into pytest with perf reporting
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py6502"
-version = "0.1.0"
-description = "A 6502 computer emulator for microchip enthusiasts and retro computing fans."
+version = "0.2.0"
+description = "Emulator of everything 6502. A cycle-accurate 6502 simulator and a DearPyGui frontend, aimed at hobbyists, educators, and retro-computing enthusiasts."
 authors = [{name = "Ricky Groenewald", email = "6112032+ricky-groenewald@users.noreply.github.com"}]
 license = {file = "LICENSE"}
 readme = "README.md"
@@ -19,11 +19,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "Topic :: Software Development :: Assemblers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Emulators",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]

--- a/src/py6502/sim/bus/component.pxd
+++ b/src/py6502/sim/bus/component.pxd
@@ -11,6 +11,7 @@ cdef class Component:
     cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
-    cdef list get_framebuffer(self)
+    cdef object get_framebuffer(self)
+    cdef void render_framebuffer(self)
     cdef bint send_input(self, unsigned char char_)
     cdef void clear_input(self)

--- a/src/py6502/sim/bus/component.pyx
+++ b/src/py6502/sim/bus/component.pyx
@@ -97,9 +97,31 @@ cdef class Component:
         """
         pass
 
-    cdef list get_framebuffer(self):
-        """Return an RGBA float list for display components. Default: None."""
+    cdef object get_framebuffer(self):
+        """
+        Return the display's RGBA float buffer. Default: None.
+
+        Concrete displays return a preallocated ``array.array('f')`` (or
+        equivalent buffer-protocol object) that they own and mutate in
+        place. The frontend binds a DearPyGui raw texture directly to
+        this buffer at system-load time; subsequent reads are pure
+        pointer returns (no allocation, no copy). The per-frame
+        refresh happens in ``render_framebuffer``, not here.
+        """
         return None
+
+    cdef void render_framebuffer(self):
+        """
+        Per-UI-frame display-refresh hook. Default: no-op.
+
+        Called once per coarse frontend call (``run_for_microseconds``,
+        ``step_cycle``, ``step_instruction``) via ``System.sync_display``,
+        which is the single chokepoint where we do the index-buffer →
+        RGBA flatten. Components that own a framebuffer override this
+        to update the buffer their ``get_framebuffer`` returns; the
+        buffer object itself stays pinned for the life of the display.
+        """
+        pass
 
     cdef bint send_input(self, unsigned char char_):
         """Accept an input byte (e.g. a key press). Default: False (ignored)."""

--- a/src/py6502/sim/graphics/textdisplay.pxd
+++ b/src/py6502/sim/graphics/textdisplay.pxd
@@ -1,4 +1,5 @@
 from libc.stdio cimport *
+from cpython.array cimport array
 
 cdef class Font:
     cdef bint* character_set
@@ -36,8 +37,16 @@ cdef class TextDisplay:
     cdef unsigned char _character_max_rows
     # _colors[i] is RGBA. i=0 background, i=1 foreground, i=2 cursor.
     cdef float[3][4] _colors
+    # RGBA output buffer (y-major, x-minor, RGBA last). Allocated once
+    # and mutated in place so the frontend's bound raw texture never
+    # sees a dangling or reassigned pointer. ``render_framebuffer``
+    # ticks the cursor and flattens ``_screen_buffer`` into it once per
+    # UI frame; ``get_screen_buffer`` is a pure ref getter.
+    cdef array _rgba_buffer
+    cdef float[::1] _rgba_view
 
-    cdef list get_screen_buffer(self)
+    cdef object get_screen_buffer(self)
+    cdef void render_framebuffer(self)
     cdef void set_cursor(self, unsigned char character, float[4] color, unsigned char cursor_mode)
     cdef void backspace(self)
     cdef void place_character(self, unsigned char character)

--- a/src/py6502/sim/graphics/textdisplay.pyx
+++ b/src/py6502/sim/graphics/textdisplay.pyx
@@ -6,9 +6,23 @@ The Font wraps a tiny custom binary format we use to pack pixel-perfect
 glyphs out of historical font ROMs. The TextDisplay treats its
 ``_screen_buffer`` as a circular row buffer so a scroll-up is just an
 index rebase, not a memcpy.
+
+The output contract is split in two:
+
+- ``render_framebuffer`` flattens the index buffer into a preallocated
+  RGBA float buffer once per UI frame. The frontend never calls this
+  directly — ``System.sync_display`` invokes it at the end of each
+  coarse frontend call.
+- ``get_screen_buffer`` is a pure reference getter. The frontend binds
+  a DearPyGui raw texture to the returned buffer once at system load
+  and re-reads the same memory every GPU upload — no Python-level
+  copies, no allocations per frame.
 """
+from cython cimport boundscheck, wraparound
 from libc.stdio cimport *
 from libc.stdlib cimport malloc, free
+from cpython.array cimport array
+import array as _pyarray
 
 cdef class Font:
     """
@@ -86,9 +100,15 @@ cdef class TextDisplay:
     State invariants worth knowing before touching this:
 
     - ``_screen_buffer[y][x]`` holds a *colour index* (0/1/2 — see
-      ``_colors``), not a packed RGBA value. The RGBA expansion only
-      happens in ``get_screen_buffer`` so we never carry around a 4×
-      buffer.
+      ``_colors``), not a packed RGBA value. Index-land is 1 byte per
+      pixel; the 4× RGBA expansion happens once per frame in
+      ``get_screen_buffer`` and lands in ``_rgba_buffer``.
+    - ``_rgba_buffer`` is the single, stable RGBA float buffer the
+      frontend's DearPyGui raw texture is bound to. Allocated once in
+      ``__init__``, mutated in place by ``get_screen_buffer``, and
+      never reassigned — rebinding it would break the texture.
+      ``_rgba_view`` is a ``float[::1]`` memoryview over the same
+      storage for cdef-speed writes.
     - ``_cursor_pos_(x|y)`` are *character* coordinates inside the
       visible grid, **not** pixel coordinates.
     - ``_start_cursor_row`` is the character-row index that the renderer
@@ -130,16 +150,41 @@ cdef class TextDisplay:
         self._character_max_cols = (resolution_x - (padding_x * 2)) // font.width
         self._character_max_rows = (resolution_y - (padding_y * 2)) // font.height
 
+        # The RGBA buffer the frontend will bind its raw texture to.
+        # Stays pinned at this address for the life of the display;
+        # ``get_screen_buffer`` mutates it in place every frame.
+        # array.array('f') gives us a buffer-protocol object DearPyGui
+        # accepts directly, with no numpy dependency. The list-times-N
+        # seed is a one-time init cost, not hot path.
+        self._rgba_buffer = _pyarray.array('f', [0.0] * (resolution_x * resolution_y * 4))
+        self._rgba_view = self._rgba_buffer
+
         self.clear_screen()
 
     def __dealloc__(self):
         if self._cursor_pixel_map:
             free(self._cursor_pixel_map)
 
-    cdef list get_screen_buffer(self):
-        # Tick the cursor blink (frame-paced, not cycle-paced — a "frame"
-        # here is one call to this method, which the frontend invokes once
-        # per UI frame).
+    cdef object get_screen_buffer(self):
+        # Pure reference getter. The frontend binds its DearPyGui raw
+        # texture to this buffer once at system load; the actual render
+        # into it happens in ``render_framebuffer`` during the sim's
+        # per-frame call. Callers must not rely on this method to
+        # refresh pixels — it only returns the pinned buffer object.
+        return self._rgba_buffer
+
+    @boundscheck(False)
+    @wraparound(False)
+    cdef void render_framebuffer(self):
+        # One-per-UI-frame render: tick the cursor blink, re-stamp the
+        # cursor glyph into the index buffer, then flatten the index
+        # buffer into the preallocated RGBA output. Invoked by
+        # ``System.sync_display`` at the end of each coarse frontend
+        # call (``run_for_microseconds`` / ``step_cycle`` /
+        # ``step_instruction``) — never per CPU cycle.
+
+        # Cursor blink is frame-paced, not cycle-paced: 30 render calls
+        # per phase ≈ half a second at 60 FPS.
         if self._cursor_mode == 1:
             self._cursor_blink_timer += 1
             if self._cursor_blink_timer == 30:
@@ -148,18 +193,53 @@ cdef class TextDisplay:
 
         self.redraw_cursor()
 
-        # Flatten the buffer into a single RGBA-per-pixel list in screen
-        # order: top padding band, then the *unwrapped* content (the
-        # post-scroll rows that should appear at the top, then the
-        # pre-scroll rows that should appear below them), then bottom
-        # padding band. The two content slices together implement the
-        # circular-buffer rotation without ever moving any pixels.
-        return (
-            [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Top padding band
-            + [rgba_val for row in range(self._start_cursor_row * self._font.height + self._pixel_padding_y, self._resolution_y - self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # Rows from the scroll origin down to the bottom of the content area
-            + [rgba_val for row in range(self._pixel_padding_y, self._start_cursor_row * self._font.height + self._pixel_padding_y) for col in range(self._resolution_x) for rgba_val in self._colors[self._screen_buffer[row][col]][:4]] # Rows from the top of the content area up to the scroll origin
-            + [rgba_val for _ in range(self._pixel_padding_y) for _ in range(self._resolution_x) for rgba_val in self._colors[0][:4]] # Bottom padding band (same colour as top)
-        )
+        # Flatten the index buffer into the preallocated RGBA output in
+        # screen order: top padding band, then the *unwrapped* content
+        # (rotated so the logical top-of-screen lands first regardless
+        # of where ``_start_cursor_row`` currently sits), then bottom
+        # padding band. The modular ``source_row`` arithmetic implements
+        # the circular-buffer rotation without moving any pixels. All
+        # the per-pixel work is cdef — no Python allocations, no list
+        # comprehensions, no object dispatch.
+        cdef unsigned int res_x = self._resolution_x
+        cdef unsigned int res_y = self._resolution_y
+        cdef unsigned int padding_y = self._pixel_padding_y
+        cdef unsigned int scroll_pixel = self._start_cursor_row * self._font.height
+        cdef unsigned int content_rows = res_y - 2 * padding_y
+        cdef unsigned int y_out, x, content_y, source_row
+        cdef unsigned char color_idx
+        cdef Py_ssize_t out_idx = 0
+        cdef float bg0 = self._colors[0][0]
+        cdef float bg1 = self._colors[0][1]
+        cdef float bg2 = self._colors[0][2]
+        cdef float bg3 = self._colors[0][3]
+
+        for y_out in range(padding_y):
+            for x in range(res_x):
+                self._rgba_view[out_idx] = bg0
+                self._rgba_view[out_idx + 1] = bg1
+                self._rgba_view[out_idx + 2] = bg2
+                self._rgba_view[out_idx + 3] = bg3
+                out_idx += 4
+
+        for y_out in range(padding_y, res_y - padding_y):
+            content_y = y_out - padding_y
+            source_row = padding_y + (content_y + scroll_pixel) % content_rows
+            for x in range(res_x):
+                color_idx = self._screen_buffer[source_row][x]
+                self._rgba_view[out_idx] = self._colors[color_idx][0]
+                self._rgba_view[out_idx + 1] = self._colors[color_idx][1]
+                self._rgba_view[out_idx + 2] = self._colors[color_idx][2]
+                self._rgba_view[out_idx + 3] = self._colors[color_idx][3]
+                out_idx += 4
+
+        for y_out in range(res_y - padding_y, res_y):
+            for x in range(res_x):
+                self._rgba_view[out_idx] = bg0
+                self._rgba_view[out_idx + 1] = bg1
+                self._rgba_view[out_idx + 2] = bg2
+                self._rgba_view[out_idx + 3] = bg3
+                out_idx += 4
 
     cdef void backspace(self):
         # Refuse to backspace past the start of the current input line

--- a/src/py6502/sim/peripherals/apple1_display.pxd
+++ b/src/py6502/sim/peripherals/apple1_display.pxd
@@ -11,4 +11,5 @@ cdef class Apple1Display(Component):
     cdef int write(self, unsigned short address, unsigned char data) except -1
     cdef void bind(self, object system)
     cdef void on_cycles_elapsed(self, unsigned long n)
-    cdef list get_framebuffer(self)
+    cdef object get_framebuffer(self)
+    cdef void render_framebuffer(self)

--- a/src/py6502/sim/peripherals/apple1_display.pyx
+++ b/src/py6502/sim/peripherals/apple1_display.pyx
@@ -77,5 +77,8 @@ cdef class Apple1Display(Component):
         if self._busy_remaining > 0:
             self._busy_remaining -= <long>n
 
-    cdef list get_framebuffer(self):
+    cdef object get_framebuffer(self):
         return self._text_display.get_screen_buffer()
+
+    cdef void render_framebuffer(self):
+        self._text_display.render_framebuffer()

--- a/src/py6502/sim/system/system.pxd
+++ b/src/py6502/sim/system/system.pxd
@@ -23,6 +23,7 @@ cdef class System:
     cpdef Registers get_registers(self)
     cpdef void set_registers(self, Registers registers)
     cpdef object get_framebuffer(self)
+    cpdef void sync_display(self)
     cpdef void register_tick_hook(self, object component)
     cpdef unsigned char peek(self, unsigned short address)
     cpdef unsigned char poke(self, unsigned short address, unsigned char data)

--- a/src/py6502/sim/system/system.pyx
+++ b/src/py6502/sim/system/system.pyx
@@ -142,7 +142,14 @@ cdef class System:
         return self._cpu_hz
 
     cpdef void run_cycles(self, unsigned long cycles) except *:
-        """Run exactly ``cycles`` CPU cycles. The hot path for the UI."""
+        """
+        Run exactly ``cycles`` CPU cycles. The low-level primitive — no
+        display sync, so tests and internal callers pay nothing for the
+        per-frame render. The frontend does not call this on the hot
+        path; it calls ``run_for_microseconds`` (which syncs) or the
+        debug-only ``step_cycle`` / ``step_instruction`` (which also
+        sync).
+        """
         if cycles:
             (<BusController>self._buses["main"]).run_cycles(cycles)
 
@@ -151,14 +158,22 @@ cdef class System:
         Run for the wall-clock elapsed time the frontend observed this
         frame. Converted to cycles against the configured ``cpu_hz`` so
         the effective frequency stays locked regardless of UI refresh
-        rate.
+        rate. Triggers the once-per-frame display render at the end, so
+        the RGBA buffer the frontend's raw texture is bound to reflects
+        the latest sim state before DPG re-uploads to the GPU.
         """
         if microseconds:
             (<BusController>self._buses["main"]).run_for_microseconds(microseconds, self._cpu_hz)
+        self.sync_display()
 
     cpdef unsigned long step_cycle(self) except *:
-        """Advance one CPU cycle. Used by the debug panel's Cycle button."""
+        """
+        Advance one CPU cycle. Used by the debug panel's Cycle button.
+        Syncs the display so single-step actions are visible in the
+        video window without waiting for the next frame tick.
+        """
         (<BusController>self._buses["main"]).run_cycles(1)
+        self.sync_display()
         return 1
 
     cpdef unsigned long step_instruction(self) except *:
@@ -169,7 +184,9 @@ cdef class System:
         least one of those two registers changes". The 16-cycle cap is
         a safety net: the longest legal 6502 instruction takes 7 cycles
         (RTI + page-cross variants), so anything past 16 means we've
-        somehow lost the marker and should bail rather than spin.
+        somehow lost the marker and should bail rather than spin. Syncs
+        the display on the way out for the same reason ``step_cycle``
+        does.
         """
         cdef BusController bus = <BusController>self._buses["main"]
         cdef Registers start = bus.get_registers()
@@ -185,6 +202,7 @@ cdef class System:
                 break
             if cycles > 16:
                 break
+        self.sync_display()
         return cycles
 
     cpdef void reset(self):
@@ -243,13 +261,28 @@ cdef class System:
     cpdef object get_framebuffer(self):
         """
         Return the display's RGBA buffer (or None if there's no display).
-        The buffer is owned by the display peripheral and mutated in
-        place — the frontend reads from it directly, never copies it
-        per frame.
+        Pure reference getter: the buffer is owned by the display
+        peripheral and stays pinned for the life of the System, so the
+        frontend can safely bind a DearPyGui raw texture to it once
+        and never re-read this method on the hot path. The render into
+        that buffer happens in ``sync_display`` (invoked at the end of
+        every coarse frontend call).
         """
         if self._display is None:
             return None
         return (<Component>self._display).get_framebuffer()
+
+    cpdef void sync_display(self):
+        """
+        Tell the display peripheral to refresh its RGBA buffer. Invoked
+        automatically at the end of ``run_for_microseconds``,
+        ``step_cycle``, and ``step_instruction`` so the frontend never
+        has to call it. Exposed publicly so tests and one-off frontend
+        paths (e.g. the initial-paint on system load) can force a
+        render without advancing any cycles.
+        """
+        if self._display is not None:
+            (<Component>self._display).render_framebuffer()
 
     cpdef void register_tick_hook(self, object component):
         """

--- a/src/py6502/ui/CLAUDE.md
+++ b/src/py6502/ui/CLAUDE.md
@@ -42,7 +42,6 @@ while dpg.is_dearpygui_running():
     if self.system is not None:
         self._drain_keys_into_system()
         self.system.run_for_microseconds(int(dt * 1_000_000))
-        self._video.update_framebuffer(self.system.get_framebuffer())
         self._debug.refresh(self.system)
     dpg.render_dearpygui_frame()
 ```
@@ -53,14 +52,20 @@ to `MAX_CATCH_UP_SECONDS` so a paused dialog or a stalled frame can't
 trigger a catch-up burst. The sim's effective frequency therefore stays
 locked to `cpu_hz` regardless of the host display's refresh rate.
 
+The video output isn't explicitly pushed per frame: at system-load time
+`VideoWindow.bind_system_framebuffer` points a DearPyGui raw texture at
+the sim's RGBA buffer. The sim mutates that buffer in place during
+`run_for_microseconds`; `render_dearpygui_frame()` re-uploads the same
+memory to the GPU with no Python-level copy.
+
 That frame body is allowed to call **exactly one** of:
 
 - `System.run_cycles(n)`
 - `System.run_for_microseconds(µs)` (µs derived from wall-clock dt)
 
-…followed by *reads* against `System.get_framebuffer()`,
-`System.get_registers()`, etc. Those reads are cheap: the framebuffer is a
-buffer the sim owns and mutates in place, not a per-frame allocation.
+…followed by *reads* against `System.get_registers()` and friends. Those
+reads are cheap: the framebuffer is owned by the sim and mutated in
+place, so the frontend never copies it on the hot path.
 
 Debug stepping (`System.step_cycle()`, `System.step_instruction()`) is
 the exception: these are called from button callbacks, not the continuous

--- a/src/py6502/ui/README.md
+++ b/src/py6502/ui/README.md
@@ -47,7 +47,6 @@ while dpg.is_dearpygui_running():
         if self._sim_running:
             self._drain_keys_into_system()
             self.system.run_for_microseconds(int(dt * 1_000_000))
-            self._video.update_framebuffer(self.system.get_framebuffer())
         self._debug.refresh(self.system)
     dpg.render_dearpygui_frame()
 ```
@@ -55,6 +54,12 @@ while dpg.is_dearpygui_running():
 This is the one invariant the frontend has to protect: **one coarse call
 to the sim per UI frame**. Anything that loops over CPU cycles from here
 is a bug, regardless of whether the tests pass.
+
+The video output doesn't need an explicit per-frame upload: the DearPyGui
+raw texture is bound directly to the sim's RGBA buffer by
+`VideoWindow.bind_system_framebuffer` at system-load time, so
+`render_dearpygui_frame()` re-reads the same memory every frame with no
+Python-level copy.
 
 The sim is paced by wall-clock `dt`, not a fixed per-frame constant, so
 its effective frequency stays locked to the configured `cpu_hz`

--- a/src/py6502/ui/app.py
+++ b/src/py6502/ui/app.py
@@ -155,7 +155,15 @@ class Py6502App:
         self._sim_running = True
         self._debug.on_reset()
         self._debug.on_sim_state_changed(running=True)
-        self._video.update_framebuffer(self.system.get_framebuffer())
+        # Rebind the raw texture onto the new display's RGBA buffer.
+        # Every subsequent frame reads directly from that buffer, so
+        # no per-frame copy is needed. sync_display populates the buffer
+        # with the current sim state (cursor visible, reset banner,
+        # etc.) so the very first rendered frame isn't all zeros —
+        # run_for_microseconds would also do this at the next tick, but
+        # that's one full frame of blank we'd rather not see.
+        self._video.bind_system_framebuffer(self.system.get_framebuffer())
+        self.system.sync_display()
         self._debug.refresh(self.system)
         dpg.focus_item(VideoWindow.VIDEO_WINDOW_TAG)
 
@@ -201,9 +209,11 @@ class Py6502App:
                         self._on_sim_error(exc)
                     else:
                         cycles_accum += (micros * self.system.cpu_hz) // 1_000_000
-                    self._video.update_framebuffer(self.system.get_framebuffer())
                 # Refresh the debug panel even when paused so single-step
-                # buttons reflect the current sim state immediately.
+                # buttons reflect the current sim state immediately. The
+                # video texture is bound to the sim's RGBA buffer by
+                # _wire_system, so no explicit upload is needed here —
+                # DPG re-uploads from the bound memory on render.
                 self._debug.refresh(self.system)
             dpg.render_dearpygui_frame()
             frame_count += 1
@@ -268,7 +278,6 @@ class Py6502App:
         self._sim_error = None
         self._debug.on_reset()
         self._play_handler()
-        self._video.update_framebuffer(self.system.get_framebuffer())
         self._debug.refresh(self.system)
         dpg.focus_item(VideoWindow.VIDEO_WINDOW_TAG)
 

--- a/src/py6502/ui/windows/debug.py
+++ b/src/py6502/ui/windows/debug.py
@@ -275,7 +275,6 @@ class DebugWindow:
         except (InvalidOPCode, UnallocatedAddressError) as exc:
             self._app._on_sim_error(exc)
             return
-        self._app._video.update_framebuffer(self._app.system.get_framebuffer())
         self.refresh(self._app.system)
 
     def _cycle_step_handler(self) -> None:
@@ -286,5 +285,4 @@ class DebugWindow:
         except (InvalidOPCode, UnallocatedAddressError) as exc:
             self._app._on_sim_error(exc)
             return
-        self._app._video.update_framebuffer(self._app.system.get_framebuffer())
         self.refresh(self._app.system)

--- a/src/py6502/ui/windows/video.py
+++ b/src/py6502/ui/windows/video.py
@@ -1,6 +1,15 @@
-"""Video output window — 256x240 framebuffer rendered at 3x magnification."""
+"""Video output window — 256x240 framebuffer rendered at 3x magnification.
+
+The texture is a DearPyGui **raw** texture bound to the sim's RGBA
+buffer. The sim mutates that buffer in place from cdef code; the
+raw-texture binding means DPG re-uploads from the same memory every
+``render_dearpygui_frame()`` with no Python-level copies. On system
+load/swap, ``bind_system_framebuffer`` rebinds the texture onto the
+newly constructed display's buffer.
+"""
 from __future__ import annotations
 
+from array import array
 from typing import TYPE_CHECKING
 
 import dearpygui.dearpygui as dpg
@@ -17,13 +26,24 @@ class VideoWindow:
 
     def __init__(self, app: Py6502App) -> None:
         self._app = app
+        # Startup placeholder buffer (shown before a System is loaded).
+        # Held on the instance so it can't be GC'd while DPG holds a
+        # raw-texture reference to it.
+        self._placeholder: array = array(
+            "f", [0.0] * (self.TEXTURE_WIDTH * self.TEXTURE_HEIGHT * 4)
+        )
+        # Whichever buffer the raw texture is currently bound to —
+        # either the placeholder above, or the sim's own RGBA buffer
+        # once bind_system_framebuffer is called. Kept referenced on
+        # the window so it outlives every DPG read.
+        self._bound_buffer: object = self._placeholder
 
     def build_texture_registry(self) -> None:
-        initial = [0.0] * (self.TEXTURE_WIDTH * self.TEXTURE_HEIGHT * 4)
         with dpg.texture_registry(show=False):
-            dpg.add_dynamic_texture(
-                self.TEXTURE_WIDTH, self.TEXTURE_HEIGHT, initial,
+            dpg.add_raw_texture(
+                self.TEXTURE_WIDTH, self.TEXTURE_HEIGHT, self._placeholder,
                 tag=self.TEXTURE_TAG,
+                format=dpg.mvFormat_Float_rgba,
             )
 
     def build(self) -> None:
@@ -42,7 +62,23 @@ class VideoWindow:
                 (self.TEXTURE_WIDTH * 3, self.TEXTURE_HEIGHT * 3 + 1),
             )
 
-    def update_framebuffer(self, framebuffer: object) -> None:
+    def bind_system_framebuffer(self, framebuffer: object) -> None:
+        """Rebind the raw texture onto a sim-owned buffer.
+
+        Called from ``Py6502App._wire_system`` whenever the active
+        System changes (preset load, user-selected YAML, reset to a
+        different config). ``framebuffer`` must be the buffer returned
+        by ``System.get_framebuffer()`` — an ``array.array('f')`` of
+        exactly ``TEXTURE_WIDTH * TEXTURE_HEIGHT * 4`` floats, owned
+        by the sim's display peripheral.
+
+        If the sim has no display (``get_framebuffer()`` returns
+        ``None``) we rebind onto the zeroed placeholder instead so the
+        texture never dangles.
+        """
+        if framebuffer is None:
+            framebuffer = self._placeholder
+        self._bound_buffer = framebuffer
         dpg.set_value(self.TEXTURE_TAG, framebuffer)
 
     def is_focused(self) -> bool:

--- a/tests/test_apple1_split.py
+++ b/tests/test_apple1_split.py
@@ -31,19 +31,35 @@ def test_keyboard_fifo_and_kbdcr_clear_on_read(apple1_system) -> None:
 
 
 def test_display_write_renders_to_framebuffer(apple1_system) -> None:
+    # The RGBA buffer is only flattened from the index buffer during
+    # ``sync_display`` (invoked at the end of every coarse frontend
+    # call). Pokes alone don't trigger it, so we call it explicitly
+    # here — the same thing the UI does automatically after
+    # run_for_microseconds / step_cycle / step_instruction.
     assert apple1_system.peek(0xD012) == 0x00
     apple1_system.poke(0xD012, ord("A"))
     assert apple1_system.peek(0xD012) == 0x80
 
+    apple1_system.sync_display()
     fb = apple1_system.get_framebuffer()
     nonzero = sum(1 for v in fb if v > 0.01)
     assert nonzero > 0, "expected the framebuffer to have non-zero pixels after DSP write"
 
 
 def test_display_framebuffer_shape(apple1_system) -> None:
+    # Display contract: get_framebuffer() returns a preallocated
+    # buffer-protocol object of RGBA floats (see
+    # ``Component.get_framebuffer`` docstring). The frontend binds a
+    # DearPyGui raw texture onto this buffer, so it must stay the same
+    # object for the life of the display — no per-call allocations.
     fb = apple1_system.get_framebuffer()
-    assert isinstance(fb, list)
-    assert len(fb) == 256 * 240 * 4
+    assert fb is not None
+    mv = memoryview(fb)
+    assert mv.format == "f"
+    assert len(mv) == 256 * 240 * 4
+    # The buffer is owned by the peripheral; consecutive calls must
+    # return the same object.
+    assert apple1_system.get_framebuffer() is fb
 
 
 def test_dsp_busy_timing_via_system_run_cycles() -> None:


### PR DESCRIPTION
## Summary

- Drops the per-frame list-comp in `TextDisplay.get_screen_buffer` — the sim now owns a stable preallocated `array.array('f')` and mutates it in place. The frontend binds a DearPyGui **raw** texture to it once at system load; DPG re-reads the same memory every `render_dearpygui_frame` with no Python-level copies.
- Splits the render out of the getter: new `Component.render_framebuffer` hook driven by a new `System.sync_display` chokepoint, invoked at the end of `run_for_microseconds` / `step_cycle` / `step_instruction`. `get_framebuffer` is now a pure reference getter — the contract its docstring already claimed.
- `VideoWindow.add_dynamic_texture` → `add_raw_texture`, plus a new `bind_system_framebuffer` method called from `_wire_system` on every system load/swap. `update_framebuffer` and its five per-frame call sites in `app.py` + `debug.py` are gone.
- Carries the v0.2 version bump in `pyproject.toml` and a ROADMAP milestone-sync that were already staged on `dev`.
- `docs/ARCHITECTURE.md` §3.1 / §3.4 / §3.5 / §3.6 / §6.2 and `src/py6502/ui/{CLAUDE,README}.md` updated to reflect the new contract.

## Why

The old `get_screen_buffer` list comprehension built a fresh ~245,760-element Python list of RGBA floats every frame, which `dpg.set_value` on a dynamic texture then copied again into its internal buffer. Measured on an Apple M1 Pro running the Apple I preset: **~85% of one core dropped to ~10%** after this change, at 120 FPS. That's two rule-5 violations (per-frame alloc) and one rule-1 violation (Python loop in steady state) in `src/py6502/sim/CLAUDE.md` fixed in one pass, plus it establishes the "preallocated RGBA buffer + cdef palette expansion + DPG raw texture binding" pattern that #69 (PixelDisplay) calls out in its acceptance criteria. The `docs/ARCHITECTURE.md` and `System.get_framebuffer` docstring already claimed this contract — the code now matches.

Splitting render from the getter avoids a subtle footgun discovered mid-PR: if the render lives inside `get_framebuffer`, the frontend has to call the getter each frame purely for its side effect. Making `sync_display` an explicit cpdef that `run_for_microseconds` invokes at its end keeps `get_framebuffer` a stable-object ref-getter the raw texture can bind to once and forget.

Related to:

- #69 PixelDisplay graphics primitive — this PR establishes the exact "preallocated RGBA target buffer; palette lookup expands in cdef on call" pattern #69 asks for. PixelDisplay becomes a copy.
- #65 v0.2 performance audit + baseline — ticks the "no per-frame allocations" acceptance box from sim-perf-reviewer.
- #40 Create Input / Display abstracts — orthogonal; the `render_framebuffer` hook can move onto the new `Display` abstract when #40 lands.

## Test plan

- [x] `pip install -e .` rebuilds Cython cleanly with no warnings about the new signatures.
- [x] `pytest` — 76/76 pass. `test_display_write_renders_to_framebuffer` updated to call `sync_display()` explicitly (the real frontend cadence); `test_display_framebuffer_shape` asserts the new buffer-protocol contract.
- [x] `python -m py6502` — Apple I preset boots, wozmon prompt renders first-frame (not a moment of black), typing echoes at DSP-busy pace, CR scrolls without tearing, cursor blinks, backspace wipes.
- [x] File → New System... swap — critical lifecycle test for the raw-texture rebind; screen does not go black or segfault.
- [x] File → Reset System — video stays live.
- [x] Debug panel *Step Cycle* / *Step Instruction* — display visibly updates per click (auto-sync via `step_*`).
- [x] **Measured:** ~85% → ~10% one-core CPU usage on an Apple M1 Pro, Apple I preset, 120 FPS.